### PR TITLE
Deprecate lane_number

### DIFF
--- a/create-feed/schemas/wzdx_v4.0_feed.json
+++ b/create-feed/schemas/wzdx_v4.0_feed.json
@@ -411,7 +411,7 @@
           "$ref": "#/definitions/LaneType"
         },
         "lane_number": {
-          "description": "The number assigned to the lane to help identify its position. Flexible, but usually used for regular, driveable lanes",
+          "description": "***DEPRECATED*** The number assigned to the lane to help identify its position. Flexible, but usually used for regular, driveable lanes",
           "type": "integer",
           "minimum": 1
         },

--- a/spec-content/objects/Lane.md
+++ b/spec-content/objects/Lane.md
@@ -7,8 +7,8 @@ Name | Type | Description | Conformance | Notes
 `order` | Positive Integer | The position of a lane in sequence on the roadway. This value is used as an index to indicate the order of all WZDx lanes provided for a road event. | Required | A value of `1` must represent the **left-most** lane and an increase in 1 must represent moving a single lane over from the **left**.
 `type` | [LaneType](/spec-content/enumerated-types/LaneType.md) | An indication of the type of lane or shoulder. | Required | 
 `status` | [LaneStatus](/spec-content/enumerated-types/LaneStatus.md) | Status of the lane for the traveling public. | Required |
-`lane_number` | Positive Integer | The number assigned to the lane to help identify its position. Flexible, but usually used for regular, driveable lanes. | Optional | Assigned by counting from the **left** edge of the improved surface. Useful for text to voice translation.
 `restrictions` | Array; \[[LaneRestriction](/spec-content/objects/LaneRestriction.md)\] | A list of specific restrictions that apply to the lane. | Optional | 
+`lane_number` (DEPRECATED) | Positive Integer | *This property is deprecated; use `order` to indicate lane positions* — The number assigned to the lane to help identify its position. Flexible, but usually used for regular, driveable lanes. | Optional | Assigned by counting from the **left** edge of the improved surface.
 
 ## Used By
 Property | Object


### PR DESCRIPTION
This PR resolves issue #153.

Specifically, it marks the `lane_number` property on the [RoadEvent](https://github.com/usdot-jpo-ode/wzdx/blob/master/spec-content/objects/RoadEvent.md) object as deprecated.