### PR TITLE
Location verify method

### DIFF
--- a/create-feed/examples/linestring-examples/comprehensive_linestring_example.geojson
+++ b/create-feed/examples/linestring-examples/comprehensive_linestring_example.geojson
@@ -15,7 +15,6 @@
         "contact_email": "solomon.sourcefeed@testcity1.gov",
         "update_frequency": 300,
         "update_date": "2020-06-18T14:37:31Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"
@@ -27,7 +26,6 @@
         "contact_email": "samuel.sourcefeed@testdot.gov",
         "update_frequency": 60,
         "update_date": "2020-06-18T14:39:01Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"
@@ -39,7 +37,6 @@
         "contact_email": "stu.sourcefeed@testcounty1.gov",
         "update_frequency": 300,
         "update_date": "2020-06-18T14:37:05Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"
@@ -51,7 +48,6 @@
         "contact_email": "skip.sourcefeed@testcity2.gov",
         "update_frequency": 60,
         "update_date": "2020-06-18T14:38:59Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/linestring-examples/local_access_only_bidirectional_linestring_example.geojson
+++ b/create-feed/examples/linestring-examples/local_access_only_bidirectional_linestring_example.geojson
@@ -15,7 +15,6 @@
         "contact_email": "solomon.sourcefeed@testcity1.gov",
         "update_frequency": 300,
         "update_date": "2020-06-18T14:37:31Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/linestring-examples/scenario1_simple_linestring_example.geojson
+++ b/create-feed/examples/linestring-examples/scenario1_simple_linestring_example.geojson
@@ -15,7 +15,6 @@
             "contact_email": "solomon.sourcefeed@testcity1.gov",
             "update_frequency": 300,
             "update_date": "2020-06-18T14:37:31Z",
-            "location_verify_method": "GPS",
             "location_method": "channel-device-method",
             "lrs_type": "milemarkers",
             "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"
@@ -27,7 +26,6 @@
             "contact_email": "samuel.sourcefeed@testdot.gov",
             "update_frequency": 60,
             "update_date": "2020-06-18T14:39:01Z",
-            "location_verify_method": "GPS",
             "location_method": "channel-device-method",
             "lrs_type": "milemarkers",
             "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/linestring-examples/scenario2_laneshift_linestring_example.geojson
+++ b/create-feed/examples/linestring-examples/scenario2_laneshift_linestring_example.geojson
@@ -15,7 +15,6 @@
         "contact_email": "solomon.sourcefeed@testcity1.gov",
         "update_frequency": 300,
         "update_date": "2020-06-18T14:37:31Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/linestring-examples/scenario3_shoulder_bidrectional_linestring_example.geojson
+++ b/create-feed/examples/linestring-examples/scenario3_shoulder_bidrectional_linestring_example.geojson
@@ -15,7 +15,6 @@
         "contact_email": "solomon.sourcefeed@testcity1.gov",
         "update_frequency": 300,
         "update_date": "2020-06-18T14:37:31Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/linestring-examples/scenario4_detour_linestring_example.geojson
+++ b/create-feed/examples/linestring-examples/scenario4_detour_linestring_example.geojson
@@ -15,7 +15,6 @@
             "contact_email": "solomon.sourcefeed@testcity1.gov",
             "update_frequency": 300,
             "update_date": "2020-06-18T14:37:31Z",
-            "location_verify_method": "GPS",
             "location_method": "channel-device-method",
             "lrs_type": "milemarkers",
             "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/linestring-examples/scenario5_recurring_linestring_example.geojson
+++ b/create-feed/examples/linestring-examples/scenario5_recurring_linestring_example.geojson
@@ -15,7 +15,6 @@
         "contact_email": "solomon.sourcefeed@testcity1.gov",
         "update_frequency": 300,
         "update_date": "2020-06-18T14:37:31Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/multipoint-examples/comprehensive_multipoint_example.geojson
+++ b/create-feed/examples/multipoint-examples/comprehensive_multipoint_example.geojson
@@ -15,7 +15,6 @@
         "contact_email": "solomon.sourcefeed@testcity1.gov",
         "update_frequency": 300,
         "update_date": "2020-06-18T14:37:31Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"
@@ -27,7 +26,6 @@
         "contact_email": "samuel.sourcefeed@testdot.gov",
         "update_frequency": 60,
         "update_date": "2020-06-18T14:39:01Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"
@@ -39,7 +37,6 @@
         "contact_email": "stu.sourcefeed@testcounty1.gov",
         "update_frequency": 300,
         "update_date": "2020-06-18T14:37:05Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"
@@ -51,7 +48,6 @@
         "contact_email": "skip.sourcefeed@testcity2.gov",
         "update_frequency": 60,
         "update_date": "2020-06-18T14:38:59Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/multipoint-examples/local_access_only_bidirectional_multipoint_example.geojson
+++ b/create-feed/examples/multipoint-examples/local_access_only_bidirectional_multipoint_example.geojson
@@ -15,7 +15,6 @@
         "contact_email": "solomon.sourcefeed@testcity1.gov",
         "update_frequency": 300,
         "update_date": "2020-06-18T14:37:31Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/multipoint-examples/scenario1_simple_multipoint_example.geojson
+++ b/create-feed/examples/multipoint-examples/scenario1_simple_multipoint_example.geojson
@@ -15,7 +15,6 @@
             "contact_email": "solomon.sourcefeed@testcity1.gov",
             "update_frequency": 300,
             "update_date": "2020-06-18T14:37:31Z",
-            "location_verify_method": "GPS",
             "location_method": "channel-device-method",
             "lrs_type": "milemarkers",
             "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"
@@ -27,7 +26,6 @@
             "contact_email": "samuel.sourcefeed@testdot.gov",
             "update_frequency": 60,
             "update_date": "2020-06-18T14:39:01Z",
-            "location_verify_method": "GPS",
             "location_method": "channel-device-method",
             "lrs_type": "milemarkers",
             "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/multipoint-examples/scenario3_shoulder_bidrectional_multipoint_example.geojson
+++ b/create-feed/examples/multipoint-examples/scenario3_shoulder_bidrectional_multipoint_example.geojson
@@ -15,7 +15,6 @@
         "contact_email": "solomon.sourcefeed@testcity1.gov",
         "update_frequency": 300,
         "update_date": "2020-06-18T14:37:31Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/multipoint-examples/scenario4_detour_multipoint_example.geojson
+++ b/create-feed/examples/multipoint-examples/scenario4_detour_multipoint_example.geojson
@@ -15,7 +15,6 @@
             "contact_email": "solomon.sourcefeed@testcity1.gov",
             "update_frequency": 300,
             "update_date": "2020-06-18T14:37:31Z",
-            "location_verify_method": "GPS",
             "location_method": "channel-device-method",
             "lrs_type": "milemarkers",
             "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/examples/multipoint-examples/scenario5_recurring_multipoint_example.geojson
+++ b/create-feed/examples/multipoint-examples/scenario5_recurring_multipoint_example.geojson
@@ -15,7 +15,6 @@
         "contact_email": "solomon.sourcefeed@testcity1.gov",
         "update_frequency": 300,
         "update_date": "2020-06-18T14:37:31Z",
-        "location_verify_method": "GPS",
         "location_method": "channel-device-method",
         "lrs_type": "milemarkers",
         "lrs_url": "https://gis.iowadot.gov/rams/rest/services/lrs"

--- a/create-feed/schemas/wzdx_v4.0_feed.json
+++ b/create-feed/schemas/wzdx_v4.0_feed.json
@@ -118,10 +118,6 @@
         "location_method": {
           "$ref": "#/definitions/LocationMethod"
         },
-        "location_verify_method": {
-          "description": "The method used to verify the accuracy of the location information",
-          "type": "string"
-        },
         "lrs_type": {
           "description": "Describes the type of linear referencing system used for the milepost measurements",
           "type": "string"
@@ -130,6 +126,10 @@
           "description": "A URL where additional information on the LRS information and transformation information is stored",
           "type": "string",
           "format": "uri"
+        },        
+        "location_verify_method": {
+          "description": "***DEPRECATED***The method used to verify the accuracy of the location information",
+          "type": "string"
         }
       },
       "required": ["data_source_id", "organization_name", "location_method"]

--- a/spec-content/enumerated-types/SpatialVerification.md
+++ b/spec-content/enumerated-types/SpatialVerification.md
@@ -4,8 +4,8 @@ An indication of how a geographical coordinate was defined.
 ## Values
 Value | Description
 --- | ---
-`estimated` | Estimated location associated with work zone activities and lane closures.<br>An estimated measurement may be based on an approximation of a location<br>referencing method (e.g., lat/long or milepost), for example: a point relative to a<br>posted milemarker, point on a map, or GPS device that provides less than<br>centimeter accuracy.
-`verified` | Actual reported information about work zone locations. Actual location is<br>typically measured by a calibrated navigation or survey system to centimeter<br>accuracy (six decimal places for latitude and longitude).
+`estimated` | Estimated location for the work zone road event geometry.  An estimated measurement is based on an approximation of the reported location of a work zone.  Approximations of the location can include but are not limited to a point relative to a posted mile maker or cross street, selecting a point on a map, or locations based on project plans.  
+`verified` | Verified locations for the work zone road event geometry representing the actual extents of the work zone.  A verified measurement is based on actual reported data from a GPS equipped device showing the measured location of the work zone.  Ths actual location is measured using a GPS device that provides the verified location of the identified location.
 
 ## Used By
 Property | Object

--- a/spec-content/objects/RoadEventDataSource.md
+++ b/spec-content/objects/RoadEventDataSource.md
@@ -13,7 +13,7 @@ Name | Type | Description | Conformance | Notes
 `contact_email` | String; [email](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.2) | The email address of the individual or group responsible for the data source. | Optional |
 `lrs_type` | String | Describes the type of linear referencing system (LRS) used for the milepost measurements. | Optional | Example: `Use of milemarkers posted by the roadways. These are registered to a dynamic segmentation of statewide LRS basemap.`
 `lrs_url` | String; [uri](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.5) | A URL where additional information on the LRS information and transformation information is stored. | Optional | Example `https://aaa.bbb.com/lrs`
-`location_verify_method` (DEPRECATED) | String | *This property is deprecated and will be removed in a future version; verified locations must use GPS devices as defined in the `Spatial Verification` enumerations* — The method used to verify the accuracy of the location information. | Optional | Example: `Survey accurate GPS equipment accurate to 0.1 cm`
+`location_verify_method` (DEPRECATED) | String | *This property is deprecated and will be removed in a future version; verified locations must use GPS devices as defined in the [SpatialVerification](/spec-content/enumerated-types/SpatialVerification.md) enumerated type* — The method used to verify the accuracy of the location information. | Optional | Example: `Survey accurate GPS equipment accurate to 0.1 cm`
 
 ## Used By
 Property | Object

--- a/spec-content/objects/RoadEventDataSource.md
+++ b/spec-content/objects/RoadEventDataSource.md
@@ -11,9 +11,9 @@ Name | Type | Description | Conformance | Notes
 `update_frequency` | Integer | The frequency in seconds at which the data source is updated. | Optional |
 `contact_name` | String | The name of the individual or group responsible for the work zone data source. | Optional | Example: `Jo Help`
 `contact_email` | String; [email](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.2) | The email address of the individual or group responsible for the data source. | Optional |
-`location_verify_method` | String | The method used to verify the accuracy of the location information. | Optional | Example: `Survey accurate GPS equipment accurate to 0.1 cm`
 `lrs_type` | String | Describes the type of linear referencing system (LRS) used for the milepost measurements. | Optional | Example: `Use of milemarkers posted by the roadways. These are registered to a dynamic segmentation of statewide LRS basemap.`
 `lrs_url` | String; [uri](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.5) | A URL where additional information on the LRS information and transformation information is stored. | Optional | Example `https://aaa.bbb.com/lrs`
+`location_verify_method` (DEPRECATED) | String | *This property is deprecated and will be removed in a future version; verified locations must use GPS devices as defined in the `Spatial Verification` enumerations* — The method used to verify the accuracy of the location information. | Optional | Example: `Survey accurate GPS equipment accurate to 0.1 cm`
 
 ## Used By
 Property | Object


### PR DESCRIPTION
This pull request addresses the issues identified in #129.  Initial discussion focused on providing a list of enumerations for the location verify method but after further discussion it was determined that verified location information should be made using a GPS equipped device (i.e. not verified through cameras, site inspection, etc).  It was determined that this would be better achieved by updating the [SpatialVerification](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/enumerated-types/SpatialVerification.md) enumerations to clarify that a GPS equipped device is required for verification and depreciating the `location_verify_method`.

As further justification the `location_verify_method` is at the data source level and wouldn't allow for different verification types for individual road events.  If this is a desired then another attribute should be added at the event level.

So in summary the changes are:
- Deprecate `location_verify_method` in the [RoadEventDataSource](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RoadEventDataSource.md)
- Redefine the [SpatialVerification](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/enumerated-types/SpatialVerification.md) enumerations to clarify that verified work zone locations should use a GPS enabled device
