### PR TITLE
Allow decimals for reduced speed limit KPH values

### DIFF
--- a/create-feed/examples/scenario1_simple_linestring_example.geojson
+++ b/create-feed/examples/scenario1_simple_linestring_example.geojson
@@ -55,7 +55,7 @@
             "end_date_accuracy": "estimated",
             "event_status": "active",
             "vehicle_impact": "some-lanes-closed",
-            "reduced_speed_limit_kph": 88
+            "reduced_speed_limit_kph": 88.514
          },
          "geometry": {
             "type": "LineString",
@@ -442,7 +442,7 @@
                   "humans-in-right-of-way"
                ]
             },
-            "reduced_speed_limit_kph": 88,
+            "reduced_speed_limit_kph": 88.514,
             "restrictions": [],
             "types_of_work": [
                {
@@ -551,7 +551,7 @@
                   "humans-in-right-of-way"
                ]
             },
-            "reduced_speed_limit_kph": 88,
+            "reduced_speed_limit_kph": 88.514,
             "restrictions": [],
             "types_of_work": [
                {
@@ -673,7 +673,7 @@
                   "humans-in-right-of-way"
                ]
             },
-            "reduced_speed_limit_kph": 88,
+            "reduced_speed_limit_kph": 88.514,
             "restrictions": [],
             "types_of_work": [
                {

--- a/create-feed/examples/scenario1_simple_multipoint_example.geojson
+++ b/create-feed/examples/scenario1_simple_multipoint_example.geojson
@@ -55,7 +55,7 @@
             "end_date_accuracy": "estimated",
             "event_status": "active",
             "vehicle_impact": "some-lanes-closed",
-            "reduced_speed_limit_kph": 88
+            "reduced_speed_limit_kph": 88.514
          },
          "geometry": {
             "type": "MultiPoint",
@@ -174,7 +174,7 @@
                   "humans-in-right-of-way"
                ]
             },
-            "reduced_speed_limit_kph": 88,
+            "reduced_speed_limit_kph": 88.514,
             "restrictions": [],
             "types_of_work": [
                {
@@ -275,7 +275,7 @@
                   "humans-in-right-of-way"
                ]
             },
-            "reduced_speed_limit_kph": 88,
+            "reduced_speed_limit_kph": 88.514,
             "restrictions": [],
             "types_of_work": [
                {
@@ -373,7 +373,7 @@
                   "humans-in-right-of-way"
                ]
             },
-            "reduced_speed_limit_kph": 88,
+            "reduced_speed_limit_kph": 88.514,
             "restrictions": [],
             "types_of_work": [
                {

--- a/create-feed/examples/scenario2_laneshift_linestring_example.geojson
+++ b/create-feed/examples/scenario2_laneshift_linestring_example.geojson
@@ -56,7 +56,7 @@
             "mobile-equipment-in-work-zone-moving"
           ]
         },
-        "reduced_speed_limit_kph": 88,
+        "reduced_speed_limit_kph": 88.5,
         "restrictions": [],
         "types_of_work": [
           {

--- a/create-feed/examples/scenario4_detour_linestring_example.geojson
+++ b/create-feed/examples/scenario4_detour_linestring_example.geojson
@@ -63,7 +63,7 @@
                   "mobile-equipment-in-work-zone-moving"
                ]
             },
-            "reduced_speed_limit_kph": 88,
+            "reduced_speed_limit_kph": 88.5,
             "types_of_work": [
                {
                   "type_name": "surface-work",

--- a/create-feed/schemas/wzdx_v4.0_feed.json
+++ b/create-feed/schemas/wzdx_v4.0_feed.json
@@ -291,7 +291,7 @@
         },
         "reduced_speed_limit_kph": {
           "description": "If applicable, the reduced speed limit posted within the road event, in kilometers per hour",
-          "type": "integer",
+          "type": "number",
           "minimum": 0
         },
         "restrictions": {

--- a/spec-content/objects/WorkZoneRoadEvent.md
+++ b/spec-content/objects/WorkZoneRoadEvent.md
@@ -23,7 +23,7 @@ Name | Type | Description | Conformance | Notes
 `event_status` | [EventStatus](/spec-content/enumerated-types/EventStatus.md) | The status of the event. | Optional |
 `types_of_work` | Array; \[[TypeOfWork](/spec-content/objects/TypeOfWork.md)\] | A list of the types of work being done in a road event and an indiciation of if each type results in an architectural change to the roadway. | Optional | 
 `worker_presence` | [WorkerPresence](/spec-content/objects/WorkerPresence.md) | Information about whether workers are present in the road event area. | Optional |
-`reduced_speed_limit_kph` | Integer | The reduced speed limit posted within the road event, in kilometers per hour. This property only needs to be supplied if the speed limit within the road event is lower than the posted speed limit of the roadway. | Optional |
+`reduced_speed_limit_kph` | Number | The reduced speed limit posted within the road event, in kilometers per hour. This property only needs to be supplied if the speed limit within the road event is lower than the posted speed limit of the roadway. | Optional |
 `restrictions` | Array; [[Restriction](/spec-content/objects/Restriction.md)] | A list of zero or more road restrictions that apply to the roadway segment described by this road event. | Optional | Restrictions can also be provided on an individual lane.
 
 ## Used By


### PR DESCRIPTION
This patch allows the renamed `reduced_speed_limit_kph` property to take numbers instead of integers, allowing more precise values for speed limits converted to km/h from mph. This minor change is backward compatible with the previously approved change and only requires approval of the WZDWG co-chairs. 