### PR TITLE
Add additional values for MarkedLocationType enumeration

### DIFF
--- a/schemas/4.0/SwzDeviceFeed.json
+++ b/schemas/4.0/SwzDeviceFeed.json
@@ -323,7 +323,7 @@
             "function"
           ]
         }
-      ]    
+      ]
     },
     "HybridSign": {
       "title": "Hybrid Sign Field Device",
@@ -576,9 +576,13 @@
         "lane-closure",
         "temporary-traffic-signal",
         "road-event-start",
+        "road-event-intermediate",
         "road-event-end",
+        "road-event-undetermined",
         "work-zone-start",
-        "work-zone-end"
+        "work-zone-intermediate",
+        "work-zone-end",
+        "work-zone-undetermined"
       ]
     }
   }

--- a/spec-content/enumerated-types/MarkedLocationType.md
+++ b/spec-content/enumerated-types/MarkedLocationType.md
@@ -10,11 +10,15 @@ Value | Description
 `lane-closure` | One or more lanes are closed.
 `temporary-traffic-signal` | A temporary traffic signal.
 `road-event-start` | The start point of a road event.
+`road-event-intermediate` | A middle point of a road event.
 `road-event-end` | The end point of a road event.
+`road-event-undetermined` | A point in a road event of undetermined order.
 `work-zone-start` | The start point of a work zone.
+`work-zone-intermediate` | A middle point of a work zone.
 `work-zone-end` | The end point of a work zone.
+`work-zone-undetermined` | A point in a work zone of undetermined order.
 
 ## Used By
 Property | Object
---- | --- 
+--- | ---
 `type` | [MarkedLocation](/spec-content/objects/MarkedLocation.md)


### PR DESCRIPTION
Location markers in a work zone (or road event) may not be exclusive to the start or end positions, or may be indeterminate in terms of order within a series of location markers. Adding the following additional values for MarkedLocationType:

- road-event-intermediate - A middle point of a road event
- road-event-undetermined - A point in a road event of undetermined order
- work-zone-intermediate - A middle point of a work zone
- work-zone-undetermined - A point in a road event of undetermined order