### PR TITLE
Fix version number in SwzDeviceFeed examples

### DIFF
--- a/examples/SwzDeviceFeed/arrow_board_ok_example.geojson
+++ b/examples/SwzDeviceFeed/arrow_board_ok_example.geojson
@@ -5,7 +5,7 @@
     "contact_name": "Robert Vendor",
     "contact_email": "robert.vendor@testvendor.com",
     "update_frequency": 60,
-    "version": "1.0",
+    "version": "4.0",
     "license": "https://creativecommons.org/publicdomain/zero/1.0/",
     "data_sources": [
       {

--- a/examples/SwzDeviceFeed/camera_error_example.geojson
+++ b/examples/SwzDeviceFeed/camera_error_example.geojson
@@ -5,7 +5,7 @@
     "contact_name": "Robert Vendor",
     "contact_email": "robert.vendor@testvendor.com",
     "update_frequency": 60,
-    "version": "1.0",
+    "version": "4.0",
     "license": "https://creativecommons.org/publicdomain/zero/1.0/",
     "data_sources": [
       {


### PR DESCRIPTION
Resolves #239 by changing the version number in the SwzDeviceFeed example JSON files from `"1.0"` to `"4.0"`.