### PR TITLE
Add is_moving to FieldDeviceCoreDetails

### DIFF
--- a/Creating_a_WZDx_Feed.md
+++ b/Creating_a_WZDx_Feed.md
@@ -40,16 +40,19 @@ The following business rules help assure a standardized and interpretable use of
 ### JSON Schemas
 The WZDx Specification defines a JSON schema for each feed (WZDx v2.0 and later) within the [schemas](/schemas) directory. The repository contains schemas for the following feeds:
 
-#### Current Version (4.0)
+#### Current Version (4.1)
+- [WZDx v4.1 WZDxFeed](/schemas/4.1/WZDxFeed.json)
+- [WZDx v4.1 SwzDeviceFeed](/schemas/4.1/SwzDeviceFeed.json)
+- [WZDx v4.1 RoadRestrictionFeed](/schemas/4.1/RoadRestrictionFeed.json)
+
+#### Previous Versions
 - [WZDx v4.0 WZDxFeed](/schemas/4.0/WZDxFeed.json)
 - [WZDx v4.0 SwzDeviceFeed](/schemas/4.0/SwzDeviceFeed.json)
 - [WZDx v4.0 RoadRestrictionFeed](/schemas/4.0/RoadRestrictionFeed.json)
-
-#### Previous Versions
-- [WZDx v2.0 WZDxFeed](/schemas/2.0/WZDxFeed.json)
-- [WZDx v3.0 WZDxFeed](/schemas/3.0/WZDxFeed.json)
 - [WZDx v3.1 WZDxFeed](/schemas/3.1/WZDxFeed.json)
-  
+- [WZDx v3.0 WZDxFeed](/schemas/3.0/WZDxFeed.json)
+- [WZDx v2.0 WZDxFeed](/schemas/2.0/WZDxFeed.json)
+ 
 ### Self-Validation Checklist
 For a list of steps to take to make sure your data feed conforms to the specification and is ready to publish, follow the [Self-Validation Checklist](/documents/WZDx_Data_Feed_Self-Validation_Checklist.docx).
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ WZDx version 4.0 implements clean up and small additions in functionality to the
 
 *For detailed release information, see [RELEASES.md](/RELEASES.md)*
 
-## Features
+#### Features
 - Add values to the [VehicleImpact](/spec-content/enumerated-types/VehicleImpact.md) enumerated type.
 - Allow restrictions with a value and unit to be provided at the road event level.
 - Add values to the [LaneType](/spec-content/enumerated-types/LaneType.md) enumerated type.
@@ -96,7 +96,7 @@ WZDx version 4.0 implements clean up and small additions in functionality to the
 - Define a new data feed, the [SwzDeviceFeed](/spec-content/objects/SwzDeviceFeed.md), to enable equipment vendors and manufacturers to provide high-level information about deployed field devices in work zones.
 - Rename the `workers_present` property on the [WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md) object to  `worker_presence`; change the type from "boolean" to a new [WorkerPresence](/spec-content/objects/WorkerPresence.md) object which enables providing more nuanced information about worker presence in work zones.
   
-## Refactoring
+#### Refactoring
 - Separate the v3.1 RoadEvent object into [RoadEventCoreDetails](/spec-content/objects/RoadEventCoreDetails.md) (details that are shared by all specific types of road events) and specific types of road events ([WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md), [DetourRoadEvent](/spec-content/objects/DetourRoadEvent.md), and [RestrictionRoadEvent](/spec-content/objects/RestrictionRoadEvent.md)) which each contain the `RoadEventCoreDetails` via a `core_details` property; update the [RoadEventFeature](/spec-content/objects/RoadEventFeature.md) `properties` property to be one of the specific road events types.
 - Move the `location_method` property from the [FeedDataSource](/spec-content/objects/FeedDataSource.md) object to the [WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md) object.
 - Change the `reduced_speed_limit` property on the [WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md) to `reduced_speed_limit_kph`; change its type from "integer" to "number" and clarify that the value should be in kilometers per hour.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Specifically, WZDx defines the structure and content of several [GeoJSON](https:
 - [Project Description](#project-description)
 - [Contact Information](#contact-information)
 - [Release Notes](#release-notes)
-    - [Release v4.0 (Dec 2021)](#wzdx-v40-december-2021)
+    - [Release v4.1 (Aug 2022)](#wzdx-v41-august-2022)
 - [Getting Started](#getting-started)
 - [JSON Schemas](#json-schemas)
 - [Contributions](#contributions)
@@ -83,32 +83,9 @@ Contact Information: [avdx@dot.gov](mailto:avdx@dot.gov?subject=Submission%20of%
 
 ## Release Notes
 
-### WZDx v4.0 (December 2021)
-WZDx version 4.0 implements clean up and small additions in functionality to the WZDx feed and adds definitions for two new feeds, the [SwzDeviceFeed](/spec-content/objects/SwzDeviceFeed.md) and [RoadRestrictionFeed](/spec-content/objects/RoadRestrictionFeed.md). Until version 4.0, the WZDx specification defined only one feed, the [WZDxFeed](/spec-content/objects/WZDxFeed.md).
+### WZDx v4.1 (August 2022)
 
-*For detailed release information, see [RELEASES.md](/RELEASES.md)*
-
-#### Features
-- Add values to the [VehicleImpact](/spec-content/enumerated-types/VehicleImpact.md) enumerated type.
-- Allow restrictions with a value and unit to be provided at the road event level.
-- Add values to the [LaneType](/spec-content/enumerated-types/LaneType.md) enumerated type.
-- Define a new data feed, the [RoadRestrictionFeed](/spec-content/objects/RoadRestrictionFeed.md), to enable providing a feed of restrictions on roadways, such as bridge clearances.
-- Define a new data feed, the [SwzDeviceFeed](/spec-content/objects/SwzDeviceFeed.md), to enable equipment vendors and manufacturers to provide high-level information about deployed field devices in work zones.
-- Rename the `workers_present` property on the [WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md) object to  `worker_presence`; change the type from "boolean" to a new [WorkerPresence](/spec-content/objects/WorkerPresence.md) object which enables providing more nuanced information about worker presence in work zones.
-  
-#### Refactoring
-- Separate the v3.1 RoadEvent object into [RoadEventCoreDetails](/spec-content/objects/RoadEventCoreDetails.md) (details that are shared by all specific types of road events) and specific types of road events ([WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md), [DetourRoadEvent](/spec-content/objects/DetourRoadEvent.md), and [RestrictionRoadEvent](/spec-content/objects/RestrictionRoadEvent.md)) which each contain the `RoadEventCoreDetails` via a `core_details` property; update the [RoadEventFeature](/spec-content/objects/RoadEventFeature.md) `properties` property to be one of the specific road events types.
-- Move the `location_method` property from the [FeedDataSource](/spec-content/objects/FeedDataSource.md) object to the [WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md) object.
-- Change the `reduced_speed_limit` property on the [WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md) to `reduced_speed_limit_kph`; change its type from "integer" to "number" and clarify that the value should be in kilometers per hour.
-- Deprecate the `lane_number` property on the [Lane](/spec-content/objects/Lane.md) object.
-- Deprecate the `lrs_type` and `lrs_url` properties on the [FeedDataSource](/spec-content/objects/FeedDataSource.md) object.
-- Remove the deprecated value `alternating-one-way` from the [LaneStatus](/spec-content/enumerated-types/LaneStatus.md) enumerated type.
-- Remove all deprecated properties from the road event (RoadEvent in previous versions; [WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md) and [RoadEventCoreDetails](/spec-content/objects/RoadEventCoreDetails.md) in 4.0).
-- Require the `road_names` property on the [RoadEventCoreDetails](/spec-content/objects/RoadEventCoreDetails.md).
-- Require the `id` property on the [RoadEventFeature](/spec-content/objects/RoadEventFeature.md).
-- Refine the [LaneType](/spec-content/enumerated-types/LaneType.md) enumerated type.
-- Deprecate the `location_verify_method` property on the [FeedDataSource](/spec-content/objects/FeedDataSource.md).
-- Update the [SpatialVerification](/spec-content/enumerated-types/SpatialVerification.md) enumerated type value descriptions to clarify that verified work zone locations should use a GPS enabled device.
+<TODO>
 
 ## Getting Started
 
@@ -124,16 +101,18 @@ The WZDWG welcomes feedback and comments on the WZDx v4.0 Specification. Comment
 ## JSON Schemas
 The WZDx Specification defines a JSON schema for each feed within the [schemas](/schemas) directory. Schemas can be used to validate a WZDx feed document for compliance to the specification. The repository contains schemas for the following feeds:
 
-### Current Version (4.0)
+### Current Version (4.1)
+- [WZDx v4.1 WZDxFeed](/schemas/4.1/WZDxFeed.json)
+- [WZDx v4.1 SwzDeviceFeed](/schemas/4.1/SwzDeviceFeed.json)
+- [WZDx v4.1 RoadRestrictionFeed](/schemas/4.1/RoadRestrictionFeed.json)
+
+### Previous Versions
 - [WZDx v4.0 WZDxFeed](/schemas/4.0/WZDxFeed.json)
 - [WZDx v4.0 SwzDeviceFeed](/schemas/4.0/SwzDeviceFeed.json)
 - [WZDx v4.0 RoadRestrictionFeed](/schemas/4.0/RoadRestrictionFeed.json)
-
-### Previous Version
-- [WZDx v2.0 WZDxFeed](/schemas/2.0/WZDxFeed.json)
-- [WZDx v3.0 WZDxFeed](/schemas/3.0/WZDxFeed.json)
 - [WZDx v3.1 WZDxFeed](/schemas/3.1/WZDxFeed.json)
-
+- [WZDx v3.0 WZDxFeed](/schemas/3.0/WZDxFeed.json)
+- [WZDx v2.0 WZDxFeed](/schemas/2.0/WZDxFeed.json)
 ## Contributions
 
 **How do I contribute to the WZDx Specification?**

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,7 @@
+# WZDx Specification v4.1
+
+<TODO>
+
 # WZDx Specification v4.0
 Released December 2021
 

--- a/examples/SwzDeviceFeed/arrow_board_ok_example.geojson
+++ b/examples/SwzDeviceFeed/arrow_board_ok_example.geojson
@@ -5,7 +5,7 @@
     "contact_name": "Robert Vendor",
     "contact_email": "robert.vendor@testvendor.com",
     "update_frequency": 60,
-    "version": "1.0",
+    "version": "4.0",
     "license": "https://creativecommons.org/publicdomain/zero/1.0/",
     "data_sources": [
       {

--- a/examples/SwzDeviceFeed/camera_error_example.geojson
+++ b/examples/SwzDeviceFeed/camera_error_example.geojson
@@ -5,7 +5,7 @@
     "contact_name": "Robert Vendor",
     "contact_email": "robert.vendor@testvendor.com",
     "update_frequency": 60,
-    "version": "1.0",
+    "version": "4.0",
     "license": "https://creativecommons.org/publicdomain/zero/1.0/",
     "data_sources": [
       {

--- a/schemas/4.1/BoundingBox.json
+++ b/schemas/4.1/BoundingBox.json
@@ -1,0 +1,11 @@
+{
+  "$id": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/BoundingBox.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GeoJSON Bounding Box",
+  "description": "Information on the coordinate range for a Geometry, Feature, or FeatureCollection",
+  "type": "array",
+  "minItems": 4,
+  "items": {
+    "type": "number"
+  }
+}

--- a/schemas/4.1/FeedInfo.json
+++ b/schemas/4.1/FeedInfo.json
@@ -1,0 +1,110 @@
+{
+  "$id": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/FeedInfo.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "WZDx Feed Information",
+  "description": "Describes WZDx feed header information such as metadata, contact information, and data sources",
+  "type": "object",
+  "properties": {
+    "publisher": {
+      "description": "The organization responsible for publishing the feed",
+      "type": "string"
+    },
+    "contact_name": {
+      "description": "The name of the individual or group responsible for the data feed",
+      "type": "string"
+    },
+    "contact_email": {
+      "description": "The email address of the individual or group responsible for the data feed",
+      "type": "string",
+      "format": "email"
+    },
+    "update_frequency": {
+      "description": "The frequency in seconds at which the data feed is updated",
+      "type": "integer",
+      "minimum": 1
+    },
+    "update_date": {
+      "description": "The UTC date and time when the GeoJSON file (representing the instance of the feed) was generated",
+      "type": "string",
+      "format": "date-time"
+    },
+    "version": {
+      "description": "The WZDx specification version used to create the data feed, in 'major.minor' format",
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+    },
+    "license": {
+      "description": "The URL of the license that applies to the data in the WZDx feed. This *must* be the string \"https://creativecommons.org/publicdomain/zero/1.0/\"",
+      "enum": [
+        "https://creativecommons.org/publicdomain/zero/1.0/"
+      ]
+    },
+    "data_sources": {
+      "description": "A list of specific data sources for the road event data in the feed",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FeedDataSource"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "update_date",
+    "version",
+    "publisher",
+    "data_sources"
+  ],
+  "definitions": {
+    "FeedDataSource": {
+      "title": "WZDx Feed Data Source",
+      "description": "Describes information about a specific data source used to build the work zone data feed",
+      "type": "object",
+      "properties": {
+        "data_source_id": {
+          "description": "Unique identifier for the organization providing work zone data",
+          "type": "string"
+        },
+        "organization_name": {
+          "description": "The name of the organization for the authoritative source of the work zone data",
+          "type": "string"
+        },
+        "contact_name": {
+          "description": "The name of the individual or group responsible for the data source",
+          "type": "string"
+        },
+        "contact_email": {
+          "description": "The email address of the individual or group responsible for the data source",
+          "type": "string",
+          "format": "email"
+        },
+        "update_frequency": {
+          "description": "The frequency in seconds at which the data source is updated",
+          "type": "integer",
+          "minimum": 1
+        },
+        "update_date": {
+          "description": "The UTC date and time when the data source was last updated",
+          "type": "string",
+          "format": "date-time"
+        },
+        "lrs_type": {
+          "description": "**DEPRECATED** Describes the type of linear referencing system used for the milepost measurements",
+          "type": "string"
+        },
+        "lrs_url": {
+          "description": "**DEPRECATED** A URL where additional information on the LRS information and transformation information is stored",
+          "type": "string",
+          "format": "uri"
+        },
+        "location_verify_method": {
+          "description": "***DEPRECATED***The method used to verify the accuracy of the location information",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data_source_id",
+        "organization_name"
+      ]
+    }
+  }
+}

--- a/schemas/4.1/RoadEventFeature.json
+++ b/schemas/4.1/RoadEventFeature.json
@@ -1,0 +1,621 @@
+
+{
+  "$id": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/RoadEventFeature.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Road Event Feature (GeoJSON Feature)",
+  "description": "The container object for a specific WZDx road event; an instance of a GeoJSON Feature",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "A unique identifier issued by the data feed provider to identify the WZDx road event",
+      "type": "string"
+    },
+    "type": {
+      "description": "The GeoJSON object type; must be 'Feature'",
+      "enum": ["Feature"]
+    },
+    "properties": {
+      "type": "object",
+      "properties": {
+        "core_details": {
+          "$ref": "#/definitions/RoadEventCoreDetails"
+        }
+      },
+      "required": ["core_details"],
+      "oneOf": [
+        {
+          "$ref": "#/definitions/WorkZoneRoadEvent"
+        },
+        {
+          "$ref": "#/definitions/DetourRoadEvent"
+        },
+        {
+          "$ref": "#/definitions/RestrictionRoadEvent"
+        }
+      ]
+    },
+    "geometry": {
+      "oneOf": [
+        {
+          "$ref": "https://geojson.org/schema/LineString.json"
+        },
+        {
+          "$ref": "https://geojson.org/schema/MultiPoint.json"
+        }
+      ]
+    },
+    "bbox": {
+      "$ref": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/BoundingBox.json"
+    }
+  },
+  "required": ["id","type","properties","geometry"],
+  "definitions": {
+    "WorkZoneRoadEvent": {
+      "title": "Work Zone Road Event",
+      "description": "Descibes a work zone road event including where, when, and what activities are taking place within a work zone on a roadway",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "core_details": {
+              "properties": {
+                "event_type": {
+                  "const": "work-zone"
+                }
+              },
+              "required": ["event_type"]
+            }
+          },
+          "required": ["core_details"]
+        },
+        {
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/RoadEventCoreDetails"
+            },
+            "beginning_cross_street": {
+              "description": "Name or number of the nearest cross street along the roadway where the event begins",
+              "type": "string"
+            },
+            "ending_cross_street": {
+              "description": "Name or number of the nearest cross street along the roadway where the event ends",
+              "type": "string"
+            },
+            "beginning_milepost": {
+              "description": "The linear distance measured against a milepost marker along a roadway where the event begins",
+              "type": "number",
+              "minimum": 0
+            },
+            "ending_milepost": {
+              "description": "The linear distance measured against a milepost marker along a roadway where the event ends",
+              "type": "number",
+              "minimum": 0
+            },
+            "beginning_accuracy": {
+              "$ref": "#/definitions/SpatialVerification"
+            },
+            "ending_accuracy": {
+              "$ref": "#/definitions/SpatialVerification"
+            },
+            "start_date": {
+              "description": "The UTC date and time (formatted according to RFC 3339, Section 5.6) when the road event begins (e.g. 2020-11-03T19:37:00Z)",
+              "type": "string",
+              "format": "date-time"
+            },
+            "end_date": {
+              "description": "The UTC date and time (formatted according to RFC 3339, Section 5.6) when the road event ends (e.g. 2020-11-03T19:37:00Z)",
+              "type": "string",
+              "format": "date-time"
+            },
+            "start_date_accuracy": {
+              "$ref": "#/definitions/TimeVerification"
+            },
+            "end_date_accuracy": {
+              "$ref": "#/definitions/TimeVerification"
+            },
+            "event_status": {
+              "$ref": "#/definitions/EventStatus"
+            },
+            "vehicle_impact": {
+              "$ref": "#/definitions/VehicleImpact"
+            },
+            "location_method": {
+              "$ref": "#/definitions/LocationMethod"
+            },
+            "worker_presence": {
+              "$ref": "#/definitions/WorkerPresence"
+            },
+            "reduced_speed_limit_kph": {
+              "description": "If applicable, the reduced speed limit posted within the road event, in kilometers per hour",
+              "type": "number",
+              "minimum": 0
+            },
+            "restrictions": {
+              "description": "A list of zero or more restrictions applying to the road event",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Restriction"
+              }
+            },
+            "types_of_work": {
+              "description": "A list of the types of work being done in a road event",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TypeOfWork"
+              }
+            },
+            "lanes": {
+              "description": "A list of individual lanes within a road event (roadway segment)",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Lane"
+              }
+            }
+          },
+          "required": [
+            "core_details",
+            "beginning_accuracy",
+            "ending_accuracy",
+            "start_date",
+            "end_date",
+            "start_date_accuracy",
+            "end_date_accuracy",
+            "vehicle_impact",
+            "location_method"
+          ]
+        }
+      ]
+    },
+    "DetourRoadEvent": {
+      "title": "Detour Road Event",
+      "description": "Descibes a detour on a roadway",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "core_details": {
+              "properties": {
+                "event_type": {
+                  "const": "detour"
+                }
+              },
+              "required": ["event_type"]
+            }
+          },
+          "required": ["core_details"]
+        },
+        {
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/RoadEventCoreDetails"
+            },
+            "beginning_cross_street": {
+              "description": "Name or number of the nearest cross street along the roadway where the event begins",
+              "type": "string"
+            },
+            "ending_cross_street": {
+              "description": "Name or number of the nearest cross street along the roadway where the event ends",
+              "type": "string"
+            },
+            "beginning_milepost": {
+              "description": "The linear distance measured against a milepost marker along a roadway where the event begins",
+              "type": "number",
+              "minimum": 0
+            },
+            "ending_milepost": {
+              "description": "The linear distance measured against a milepost marker along a roadway where the event ends",
+              "type": "number",
+              "minimum": 0
+            },
+            "start_date": {
+              "description": "The UTC date and time (formatted according to RFC 3339, Section 5.6) when the road event begins (e.g. 2020-11-03T19:37:00Z)",
+              "type": "string",
+              "format": "date-time"
+            },
+            "end_date": {
+              "description": "The UTC date and time (formatted according to RFC 3339, Section 5.6) when the road event ends (e.g. 2020-11-03T19:37:00Z)",
+              "type": "string",
+              "format": "date-time"
+            },
+            "start_date_accuracy": {
+              "$ref": "#/definitions/TimeVerification"
+            },
+            "end_date_accuracy": {
+              "$ref": "#/definitions/TimeVerification"
+            },
+            "event_status": {
+              "$ref": "#/definitions/EventStatus"
+            }
+          },
+          "required": [
+            "core_details",
+            "start_date",
+            "end_date",
+            "start_date_accuracy",
+            "end_date_accuracy"
+          ]
+        }
+      ]
+    },
+    "RestrictionRoadEvent": {
+      "title": "Restriction Road Event",
+      "description": "A road event describing a section of roadway and the limitations of how that section can be used",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "core_details": {
+              "properties": {
+                "event_type": {
+                  "const": "restriction"
+                }
+              },
+              "required": ["event_type"]
+            }
+          },
+          "required": ["core_details"]
+        },
+        {
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/RoadEventCoreDetails"
+            },
+            "restrictions": {
+              "description": "A list of zero or more restrictions applying to the road event",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Restriction"
+              }
+            },
+            "lanes": {
+              "description": "A list of individual lanes within a road event (roadway segment)",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Lane"
+              }
+            }
+          },
+          "required": [
+            "core_details"
+          ],
+          "anyOf": [
+            {
+              "required": [
+                "restrictions"
+              ]
+            },
+            {
+              "required": [
+                "lanes"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "RoadEventCoreDetails": {
+      "title": "Road Event Core Details",
+      "description": "The core details of an event occurring on a roadway (i.e. a road event) that is shared by all types of road events",
+      "type": "object",
+      "properties": {
+        "data_source_id": {
+          "description": "Identifies the data source from which the road event data is sourced from",
+          "type": "string"
+        },
+        "event_type": {
+          "$ref": "#/definitions/EventType"
+        },
+        "relationship": {
+          "$ref": "#/definitions/Relationship"
+        },
+        "road_names": {
+          "description": "A list of publicly known names of the road on which the event occurs. This may include the road number designated by a jurisdiction such as a county, state or interstate (e.g. I-5, VT 133)",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "direction": {
+          "$ref": "#/definitions/Direction"
+        },
+        "description": {
+          "description": "Short free text description of the road event",
+          "type": "string"
+        },
+        "creation_date": {
+          "description": "The UTC date and time (formatted according to RFC 3339, Section 5.6) when the road event was created (e.g. 2020-11-03T19:37:00Z)",
+          "type": "string",
+          "format": "date-time"
+        },
+        "update_date": {
+          "description": "The UTC date and time (formatted according to RFC 3339, Section 5.6) when the road event was last updated (e.g. 2020-11-03T19:37:00Z)",
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "event_type",
+        "data_source_id",
+        "direction",
+        "road_names"
+      ]
+    },
+    "LocationMethod": {
+      "title": "Location Method Enumerated Type",
+      "description": "The typical method used to locate the beginning and end of a work zone impact area",
+      "enum": [
+        "channel-device-method",
+        "sign-method",
+        "junction-method",
+        "other",
+        "unknown"
+      ]
+    },"Relationship": {
+      "title": "Relationship",
+      "description": "Identifies both sequential and hierarchical relationships between road events and other entities. For example, a relationship can be used to link multiple road events to a common 'parent', such as a project or phase, or identify a sequence of road events",
+      "type": "object",
+      "properties": {
+        "first": {
+          "description": "Indicates the first (can be multiple) road event in a sequence of road events by RoadEventFeature 'id'",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "next": {
+          "description": "Indicates the next (can be multiple) road event in a sequence of road events by RoadEventFeature 'id'",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "parents": {
+          "description": "Indicates entities that the road event with this relationship is a part of, such as a work zone project or phase. Values can but do not have to correspond to a WZDx entity",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "children": {
+          "description": "Indicates entities that are part of the road event with this relationship, such as a detour or piece of equipment. Values can but do not have to correspond to a WZDx entity",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TypeOfWork": {
+      "title": "Type of Work",
+      "description": "A description of the type of work being done in a road event and an indication of if that work will result in an architectural change to the roadway",
+      "type": "object",
+      "properties": {
+        "type_name": {
+          "$ref": "#/definitions/WorkTypeName"
+        },
+        "is_architectural_change": {
+          "description": "A flag indicating whether the type of work will result in an architectural change to the roadway",
+          "type": "boolean"
+        }
+      },
+      "required": ["type_name"]
+    },
+    "Lane": {
+      "title": "Lane",
+      "description": "An individual lane within a road event",
+      "type": "object",
+      "properties": {
+        "order": {
+          "description": "The position (index) of the lane in sequence on the roadway, where '1' represents the left-most lane",
+          "type": "integer",
+          "minimum": 1
+        },
+        "status": {
+          "$ref": "#/definitions/LaneStatus"
+        },
+        "type": {
+          "$ref": "#/definitions/LaneType"
+        },
+        "lane_number": {
+          "description": "***DEPRECATED*** The number assigned to the lane to help identify its position. Flexible, but usually used for regular, driveable lanes",
+          "type": "integer",
+          "minimum": 1
+        },
+        "restrictions": {
+          "description": "A list of zero or more restrictions specific to the lane",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Restriction"
+          }
+        }
+      },
+      "required": ["status", "type", "order"]
+    },
+    "Restriction": {
+      "title": "Restriction",
+      "description": "A restriction on a roadway or lane, including type and value",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/RestrictionType"
+        },
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "$ref": "#/definitions/UnitOfMeasurement"
+        }
+      },
+      "required": ["type"],
+      "dependencies": {
+        "value": ["unit"]
+      }
+    },
+    "WorkerPresence": {
+      "title": "Worker Presence",
+      "description": "Information about the presence of workers in the work zone event area",
+      "type": "object",
+      "properties": {
+        "are_workers_present": {
+          "description": "Whether workers are present in the work zone event area, following the definition provided in the ‘definition’ property on the WorkerPresence object",
+          "type": "boolean"
+        },
+        "method": {
+          "$ref": "#/definitions/WorkerPresenceMethod"
+        },
+        "worker_presence_last_confirmed_date": {
+          "description": "The UTC date and time at which the presence of workers was last confirmed",
+          "type": "string",
+          "format": "date-time"
+        },
+        "confidence": {
+          "$ref": "#/definitions/WorkerPresenceConfidence"
+        },
+        "definition": {
+          "description": "A list of situations in which workers are considered to be present in the jurisdiction of the data provider",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WorkerPresenceDefinition"
+          },
+          "uniqueItems": true
+        }
+      },
+      "required": ["are_workers_present"]
+    },
+    "EventType": {
+      "title": "Road Event Type Enumerated Type",
+      "description": "The type of WZDx road event",
+      "enum": ["work-zone", "detour", "restriction"]
+    },
+    "Direction": {
+      "title": "Direction Enumerated Type",
+      "description": "The direction for a road event based on standard naming for US roads; indicates the direction the traffic flow regardless of the real heading angle",
+      "enum": ["northbound", "eastbound", "southbound", "westbound"]
+    },
+    "SpatialVerification": {
+      "title": "Spatial Verification Enumerated Type",
+      "description": "An indication of how a geographical coordinate was defined",
+      "enum": ["estimated", "verified"]
+    },
+    "TimeVerification": {
+      "title": "Time Verification Enumerated Type",
+      "description": "A measure of how accurate a date-time is",
+      "enum": ["estimated", "verified"]
+    },
+    "EventStatus": {
+      "title": "Event Status Enumerated Type",
+      "description": "The status of the road event",
+      "enum": ["planned", "pending", "active", "completed", "cancelled"]
+    },
+    "VehicleImpact": {
+      "title": "Vehicle Impact Enumerated Type",
+      "description": "The impact to vehicular lanes along a single road in a single direction",
+      "enum": ["all-lanes-closed", "some-lanes-closed", "all-lanes-open", "alternating-one-way", "some-lanes-closed-merge-left", "some-lanes-closed-merge-right", "all-lanes-open-shift-left", "all-lanes-open-shift-right", "some-lanes-closed-split", "flagging", "temporary-traffic-signal", "unknown"]
+    },
+    "RestrictionType": {
+      "title": "Restriction Type Enumerated Type",
+      "description": "The type of vehicle restriction on a roadway",
+      "enum": [
+        "no-trucks",
+        "travel-peak-hours-only",
+        "hov-3",
+        "hov-2",
+        "no-parking",
+        "reduced-width",
+        "reduced-height",
+        "reduced-length",
+        "reduced-weight",
+        "axle-load-limit",
+        "gross-weight-limit",
+        "towing-prohibited",
+        "permitted-oversize-loads-prohibited",
+        "local-access-only"
+      ]
+    },
+    "WorkTypeName": {
+      "title": "Work Type Name Enumerated Type",
+      "description": "A high-level text description of the type of work being done in a road event",
+      "enum": [
+        "maintenance",
+        "minor-road-defect-repair",
+        "roadside-work",
+        "overhead-work",
+        "below-road-work",
+        "barrier-work",
+        "surface-work",
+        "painting",
+        "roadway-relocation",
+        "roadway-creation"
+      ]
+    },
+    "LaneStatus": {
+      "title": "Lane Status Enumerated Type",
+      "description": "The status of the lane for the traveling public",
+      "enum": ["open", "closed", "shift-left", "shift-right", "merge-left", "merge-right", "alternating-flow"]
+    },
+    "LaneType": {
+      "title": "Lane Type Enumerated Type",
+      "description": "An indication of the type of lane or shoulder",
+      "enum": [
+        "general",
+        "exit-lane",
+        "exit-ramp",
+        "entrance-lane",
+        "entrance-ramp",
+        "sidewalk",
+        "bike-lane",
+        "shoulder",
+        "parking",
+        "median",
+        "center-left-turn-lane"
+      ]
+    },
+    "UnitOfMeasurement": {
+      "title": "Unit of Measurement Enumerated Type",
+      "description": "Unit of measurement, used when providing a unit to accompany a value",
+      "enum": ["feet", "inches", "centimeters", "pounds", "tons", "kilograms"]
+    },
+    "WorkerPresenceMethod": {
+      "title": "Worker Presence Method Enumerated Type",
+      "description": "Describes methods for how worker presence in a work zone event area is determined",
+      "enum": [
+        "camera-monitoring", 
+        "arrow-board-present", 
+        "cones-present", 
+        "maintenance-vehicle-present", 
+        "wearables-present", 
+        "mobile-device-present", 
+        "check-in-app", 
+        "check-in-verbal",
+        "scheduled"
+      ]
+    },
+    "WorkerPresenceDefinition": {
+      "title": "Worker Presence Definition Enumerated Type",
+      "description": "Situations in which workers may be considered present in a work zone",
+      "enum": [
+        "workers-in-work-zone-working",
+        "workers-in-work-zone-not-working", 
+        "mobile-equipment-in-work-zone-moving", 
+        "mobile-equipment-in-work-zone-not-working", 
+        "fixed-equipment-in-work-zone", 
+        "humans-behind-barrier", 
+        "humans-in-right-of-way"
+      ]
+    },
+    "WorkerPresenceConfidence": {
+      "title": "Worker Presence Confidence Enumerated Type",
+      "description": "A high-level description of the feed publisher's confidence in the reported WorkerPresence value of are_workers_present",
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    }
+  }
+}

--- a/schemas/4.1/RoadRestrictionFeed.json
+++ b/schemas/4.1/RoadRestrictionFeed.json
@@ -1,0 +1,55 @@
+{
+  "$id": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/RoadRestrictionFeed.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "WZDx v4.1 Road Restriction Feed",
+  "description": "The GeoJSON output of a WZDx road restriction data feed (v4.1)",
+  "type": "object",
+  "properties": {
+    "feed_info": {
+      "$ref": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/FeedInfo.json"
+    },
+    "type": {
+      "description": "The GeoJSON type",
+      "enum": [
+        "FeatureCollection"
+      ]
+    },
+    "features": {
+      "description": "An array of GeoJSON Feature objects which represent WZDx restriction road events",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "properties": {
+              "properties": {
+                "properties": {
+                  "core_details": {
+                    "properties": {
+                      "event_type": {
+                        "const": "restriction"
+                      }
+                    },
+                    "required": ["event_type"]
+                  }
+                },
+                "required": ["core_details"]
+              }
+            },
+            "required": ["properties"]
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/RoadEventFeature.json"
+          }
+        ]
+      }
+    },
+    "bbox": {
+      "$ref": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/BoundingBox.json"
+    }
+  },
+  "required": [
+    "feed_info",
+    "type",
+    "features"
+  ]
+}

--- a/schemas/4.1/SwzDeviceFeed.json
+++ b/schemas/4.1/SwzDeviceFeed.json
@@ -1,0 +1,585 @@
+{
+  "$id": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/SwzDeviceFeed.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "WZDx v4.1 SwzDeviceFeed",
+  "description": "The GeoJSON output of a WZDx smart work zone device data feed (v4.1)",
+  "type": "object",
+  "properties": {
+    "feed_info": {
+      "$ref": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/FeedInfo.json"
+    },
+    "type": {
+      "description": "The GeoJSON type",
+      "enum": ["FeatureCollection"]
+    },
+    "features": {
+      "description": "An array of GeoJSON Feature objects which represent field devices deployed in a smart work zone",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FieldDeviceFeature"
+      }
+    },
+    "bbox": {
+      "$ref": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/BoundingBox.json"
+    }
+  },
+  "required": ["feed_info", "type", "features"],
+  "definitions": {
+    "FieldDeviceFeature": {
+      "title": "Field Device Feature (GeoJSON Feature)",
+      "description": "The GeoJSON feature container for a WZDx field device",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "A unique identifier issued by the data feed provider to identify the field device",
+          "type": "string"
+        },
+        "type": {
+          "description": "The GeoJSON object type; must be 'Feature'",
+          "enum": ["Feature"]
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/FieldDeviceCoreDetails"
+            }
+          },
+          "required": ["core_details"],
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ArrowBoard"
+            },
+            {
+              "$ref": "#/definitions/Camera"
+            },
+            {
+              "$ref": "#/definitions/DynamicMessageSign"
+            },
+            {
+              "$ref": "#/definitions/FlashingBeacon"
+            },
+            {
+              "$ref": "#/definitions/HybridSign"
+            },
+            {
+              "$ref": "#/definitions/LocationMarker"
+            },
+            {
+              "$ref": "#/definitions/TrafficSensor"
+            }
+          ]
+        },
+        "geometry": {
+          "oneOf": [
+            {
+              "$ref": "https://geojson.org/schema/Point.json"
+            }
+          ]
+        },
+        "bbox": {
+          "$ref": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/BoundingBox.json"
+        }
+      },
+      "required": ["id","type","properties","geometry"]
+    },
+    "FieldDeviceCoreDetails": {
+      "title": "Field Device Core Details",
+      "description": "The core details—both configuration and current state—of a field device that are shared by all types of field devices",
+      "type": "object",
+      "properties": {
+        "device_type": {
+          "$ref": "#/definitions/FieldDeviceType"
+        },
+        "data_source_id": {
+          "description": "Identifies the data source from which the field device information is sourced from",
+          "type": "string"
+        },
+        "road_names": {
+          "description": "A list of publicly known names of the road on which the field device is located. This may include the road number designated by a jurisdiction such as a county, state or interstate (e.g. I-5, VT 133)",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "device_status": {
+          "$ref": "#/definitions/FieldDeviceStatus"
+        },
+        "update_date": {
+          "description": "The UTC date and time (formatted according to RFC 3339, Section 5.6) when the field device data was last updated (e.g. 2020-11-03T19:37:00Z)",
+          "type": "string",
+          "format": "date-time"
+        },
+        "has_automatic_location": {
+          "description": "A yes/no value indicating if the field device location (parent FieldDeviceFeature's geometry) is determined automatically from an onboard GPS (true) or manually set/overidden (false)",
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string",
+          "description": "A human-readable name for the field device"
+        },
+        "description": {
+          "type": "string",
+          "description": "A description of the field device."
+        },
+        "status_messages": {
+          "type": "array",
+          "description": "A list of messages associated with the device's status, if applicable. Used to provide additional information about the status such as specific warning or error message.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "road_event_ids": {
+          "type": "array",
+          "description": "A list of one or more IDs of a RoadEventFeatures that the device is associated with",
+          "items": {
+            "type": "string"
+          }
+        },
+        "milepost": {
+          "type": "number",
+          "description": "The linear distance measured against a milepost marker along a roadway where the device is located"
+        },
+        "make": {
+          "type": "string",
+          "description": "The make or manufacturer of the device"
+        },
+        "model": {
+          "type": "string",
+          "description": "The model of the device"
+        },
+        "serial_number": {
+          "type": "string",
+          "description": "The serial number of the device"
+        },
+        "firmware_version": {
+          "type": "string",
+          "description": "The version of firmware the device is using to operate"
+        }
+      },
+      "required": [
+        "device_type",
+        "data_source_id",
+        "road_names",
+        "device_status",
+        "update_date",
+        "has_automatic_location"
+      ]
+    },
+    "ArrowBoard": {
+      "title": "Arrow Board Field Device",
+      "description": "An electronic, connected arrow board which can display an arrow pattern to direct traffic",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "core_details": {
+              "properties": {
+                "device_type": {
+                  "const": "arrow-board"
+                }
+              },
+              "required": ["device_type"]
+            }
+          },
+          "required": ["core_details"]
+        },
+        {
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/FieldDeviceCoreDetails"
+            },
+            "pattern": {
+              "$ref": "#/definitions/ArrowBoardPattern"
+            },
+            "is_moving": {
+              "type": "boolean",
+              "description": "A yes/no value indicating if the arrow board is actively moving (not statically placed) as part of a mobile work zone operation."
+            },
+            "is_in_transport_position": {
+              "type": "boolean",
+              "description": "A yes/no value indicating if the arrow board is in the stowed/transport position (true) or deployed/upright position (false)"
+            }
+          },
+          "required": [
+            "core_details",
+            "pattern"
+          ]
+        }
+      ]
+    },
+    "Camera": {
+      "title": "Camera Field Device",
+      "description": "A camera device deployed in the field, capable of capturing still images",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "core_details": {
+              "properties": {
+                "device_type": {
+                  "const": "camera"
+                }
+              },
+              "required": ["device_type"]
+            }
+          },
+          "required": ["core_details"]
+        },
+        {
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/FieldDeviceCoreDetails"
+            },
+            "image_url": {
+              "type": "string",
+              "format": "uri",
+              "description": "A URL pointing to an image file for the camera image still"
+            },
+            "image_timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The UTC date and time when the image was captured"
+            }
+          },
+          "required": [
+            "core_details"
+          ],
+          "dependencies": {
+            "image_url": [
+              "image_timestamp"
+            ]
+          }
+        }
+      ]
+    },
+    "DynamicMessageSign": {
+      "title": "Dynamic Message Sign Field Device",
+      "description": "An electronic traffic sign deployed on the roadway, used to provide information to travelers",
+      "allOf": [
+        {
+          "properties": {
+            "core_details": {
+              "properties": {
+                "device_type": {
+                  "const": "dynamic-message-sign"
+                }
+              },
+              "required": ["device_type"]
+            }
+          },
+          "required": ["core_details"]
+        },
+        {
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/FieldDeviceCoreDetails"
+            },
+            "message_multi_string": {
+              "type": "string",
+              "description": "A MULTI-formatted string describing the message currently posted to the sign"
+            }
+          },
+          "required": [
+            "core_details",
+            "message_multi_string"
+          ]
+        }
+      ]
+    },
+    "FlashingBeacon": {
+      "title": "Flashing Beacon Field Device",
+      "description": "A flashing beacon light of any form (e.g. trailer-mounted, vehicle), used to indicate something and capture driver attention",
+      "allOf": [
+        {
+          "properties": {
+            "core_details": {
+              "properties": {
+                "device_type": {
+                  "const": "flashing-beacon"
+                }
+              },
+              "required": ["device_type"]
+            }
+          },
+          "required": ["core_details"]
+        },
+        {
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/FieldDeviceCoreDetails"
+            },
+            "function": {
+              "$ref": "#/definitions/FlashingBeaconFunction"
+            },
+            "is_flashing": {
+              "type": "boolean",
+              "description": "A yes/no value indicating if the flashing beacon is currently in use and flashing"
+            }
+          },
+          "required": [
+            "core_details",
+            "function"
+          ]
+        }
+      ]    
+    },
+    "HybridSign": {
+      "title": "Hybrid Sign Field Device",
+      "description": "A hybrid sign that contains static text (e.g. on an aluminum sign) along with a single electronic message display, used to provide information to travelers",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "core_details": {
+              "properties": {
+                "device_type": {
+                  "const": "hybrid-sign"
+                }
+              },
+              "required": ["device_type"]
+            }
+          },
+          "required": ["core_details"]
+        },
+        {
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/FieldDeviceCoreDetails"
+            },
+            "dynamic_message_function": {
+              "$ref": "#/definitions/HybridSignDynamicMessageFunction"
+            },
+            "dynamic_message_text": {
+              "type": "string",
+              "description": "A text representation of the message currently posted to the dynamic electronic component of the hybrid sign"
+            },
+            "static_sign_text": {
+              "type": "string",
+              "description": "The static text on the non-electronic component of the hybrid sign"
+            }
+          },
+          "required": [
+            "core_details",
+            "dynamic_message_function"
+          ]
+        }
+      ]
+    },
+    "LocationMarker": {
+      "title": "Location Marker Field Device",
+      "description": "Any GPS-enabled ITS device that is placed at a point on a roadway to dynamically know the location of something (often the beginning or end of a work zone)",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "core_details": {
+              "properties": {
+                "device_type": {
+                  "const": "location-marker"
+                }
+              },
+              "required": ["device_type"]
+            }
+          },
+          "required": ["core_details"]
+        },
+        {
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/FieldDeviceCoreDetails"
+            },
+            "marked_locations": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/MarkedLocation"
+              }
+            }
+          },
+          "required": ["core_details", "marked_locations"]
+        }
+      ]
+    },
+    "MarkedLocation": {
+      "title": "Marked Location",
+      "description": "Describes a specific location where a LocationMarker is placed, such as the start or end of a work zone road event",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/MarkedLocationType"
+        },
+        "road_event_id": {
+          "type": "string",
+          "description": "The ID of a RoadEventFeature that the MarkedLocation applies to"
+        }
+      },
+      "required": ["type"]
+    },
+    "TrafficSensor": {
+      "title": "Traffic Sensor Field Device",
+      "description": "A traffic sensor deployed on a roadway which captures traffic metrics (e.g. speed, volume, occupancy) over a collection interval",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "core_details": {
+              "properties": {
+                "device_type": {
+                  "const": "traffic-sensor"
+                }
+              },
+              "required": ["device_type"]
+            }
+          },
+          "required": ["core_details"]
+        },
+        {
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/FieldDeviceCoreDetails"
+            },
+            "collection_interval_start_date": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The UTC date and time where the TrafficSensor data collection started. The averages and totals contained in the TrafficSensor data apply to the inclusive interval of 'collection_interval_start_date' to 'collection_interval_end_date'"
+            },
+            "collection_interval_end_date": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The UTC date and time where the TrafficSensor data collection ended. The averages and totals contained in the TrafficSensor data apply to the inclusive interval of 'collection_interval_start_date' to 'collection_interval_end_date'"
+            },
+            "average_speed_kph": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The average speed of vehicles across all lanes over the collection interval in kilometers per hour"
+            },
+            "volume_vph": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The rate of vehicles passing by the sensor during the collection interval in vehicles per hour"
+            },
+            "occupancy_percent": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The percent of time the roadway section monitored by the sensor was occupied by a vehicle over the collection interval"
+            },
+            "lane_data": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TrafficSensorLaneData"
+              }
+            }
+          },
+          "required": [
+            "core_details",
+            "collection_interval_start_date",
+            "collection_interval_end_date"
+          ]
+        }
+      ]
+    },
+    "TrafficSensorLaneData": {
+      "title": "Traffic Sensor Lane Data",
+      "description": "data for a single lane within a RoadEvent measured by a TrafficSensor deployed on the roadway",
+      "properties": {
+        "road_event_id": {
+          "type": "string",
+          "description": "The ID of a RoadEventFeature that the measured lane occurs in"
+        },
+        "lane_order": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The lane's position in sequence within the road event specified by the 'road_event_id' property"
+        },
+        "average_speed_kph": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The average speed of traffic in the lane over the collection interval (in kilometers per hour)"
+        },
+        "volume_vph": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The rate of vehicles passing by the sensor in the lane during the collection interval (in vehicles per hour)"
+        },
+        "occupancy_percent": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The percent of time the lane monitored by the sensor was occupied by a vehicle over the collection interval"
+        }
+      },
+      "required": [
+        "road_event_id",
+        "lane_order"
+      ]
+    },
+    "ArrowBoardPattern": {
+      "title": "Arrow Board Pattern Enumerated Type",
+      "description": "a list of options for the posted pattern on an ArrowBoard",
+      "enum": [
+        "bidirectional-arrow-flashing",
+        "bidirectional-arrow-static",
+        "blank",
+        "diamonds-alternating",
+        "four-corners-flashing",
+        "left-arrow-flashing",
+        "left-arrow-sequential",
+        "left-arrow-static",
+        "left-chevron-flashing",
+        "left-chevron-sequential",
+        "left-chevron-static",
+        "line-flashing",
+        "right-arrow-flashing",
+        "right-arrow-sequential",
+        "right-arrow-static",
+        "right-chevrons-flashing",
+        "right-chevrons-sequential",
+        "right-chevrons-static",
+        "unknown"
+      ]
+    },
+    "FieldDeviceType": {
+      "title": "Field Device Type Enumerated Type",
+      "description": "The type of field device",
+      "enum": [
+        "arrow-board",
+        "camera",
+        "dynamic-message-sign",
+        "flashing-beacon",
+        "hybrid-sign",
+        "location-marker",
+        "traffic-sensor"
+      ]
+    },
+    "FieldDeviceStatus": {
+      "title": "Field Device Status Enumerated Type",
+      "description": "The operational status of a field device",
+      "enum": ["ok", "warning", "error", "unknown"]
+    },
+    "FlashingBeaconFunction": {
+      "title": "Flashing Beacon Function Enumerated Type",
+      "description": "Options for what a FlashingBeacon is being used to indicate",
+      "enum": ["vehicle-entering", "queue-warning", "reduced-speed", "workers-present"]
+    },
+    "HybridSignDynamicMessageFunction": {
+      "title": "Hybrid Sign Dynamic Message Function Enumerated Type",
+      "description": "Options for the function of the dynamic message displayed by the electronic display on a HybridSign",
+      "enum": ["speed-limit", "travel-time", "other"]
+    },
+    "MarkedLocationType": {
+      "title": "Marked Location Type Enumerated Type",
+      "description": "Options for what a MarkedLocation can mark, such as the start or end of a road event",
+      "enum": [
+        "afad",
+        "flagger",
+        "lane-shift",
+        "lane-closure",
+        "temporary-traffic-signal",
+        "road-event-start",
+        "road-event-end",
+        "work-zone-start",
+        "work-zone-end"
+      ]
+    }
+  }
+}

--- a/schemas/4.1/SwzDeviceFeed.json
+++ b/schemas/4.1/SwzDeviceFeed.json
@@ -130,6 +130,10 @@
             "type": "string"
           }
         },
+        "is_moving": {
+          "type": "boolean",
+          "description": "A yes/no value indicating if the device is actively moving (not statically placed) as part of a mobile work zone operation."
+        },
         "road_event_ids": {
           "type": "array",
           "description": "A list of one or more IDs of a RoadEventFeatures that the device is associated with",
@@ -195,7 +199,7 @@
             },
             "is_moving": {
               "type": "boolean",
-              "description": "A yes/no value indicating if the arrow board is actively moving (not statically placed) as part of a mobile work zone operation."
+              "description": "**DEPRECATED** A yes/no value indicating if the arrow board is actively moving (not statically placed) as part of a mobile work zone operation."
             },
             "is_in_transport_position": {
               "type": "boolean",

--- a/schemas/4.1/WZDxFeed.json
+++ b/schemas/4.1/WZDxFeed.json
@@ -1,0 +1,49 @@
+{
+  "$id": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/WZDxFeed.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "WZDx v4.1 WZDxFeed",
+  "description": "The GeoJSON output of a WZDx feed data feed (v4.1)",
+  "type": "object",
+  "properties": {
+    "road_event_feed_info": {
+      "$ref": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/FeedInfo.json"
+    },
+    "type": {
+      "description": "The GeoJSON type",
+      "enum": ["FeatureCollection"]
+    },
+    "features": {
+      "description": "An array of GeoJSON Feature objects which represent WZDx road events",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "properties": {
+              "properties": {
+                "properties": {
+                  "core_details": {
+                    "properties": {
+                      "event_type": {
+                        "enum": ["work-zone", "detour"]
+                      }
+                    },
+                    "required": ["event_type"]
+                  }
+                },
+                "required": ["core_details"]
+              }
+            },
+            "required": ["properties"]
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/RoadEventFeature.json"
+          }
+        ]
+      }
+    },
+    "bbox": {
+      "$ref": "https://raw.githubusercontent.com/usdot-jpo-ode/wzdx/main/schemas/4.0/BoundingBox.json"
+    }
+  },
+  "required": ["road_event_feed_info", "type", "features"]    
+}

--- a/spec-content/objects/ArrowBoard.md
+++ b/spec-content/objects/ArrowBoard.md
@@ -8,8 +8,8 @@ Name | Type | Description | Conformance | Notes
 --- | --- | --- | --- | ---
 `core_details` | [FieldDeviceCoreDetails](/spec-content/objects/FieldDeviceCoreDetails.md) | The core details of the field device that are shared by all types of field devices, not specific to arrow boards. | Required | This property appears on all field devices.
 `pattern` | [ArrowBoardPattern](/spec-content/enumerated-types/ArrowBoardPattern.md) | The current pattern displayed on the arrow board. Note this includes `blank`, which indicates that nothing is shown on the arrow board. | Required |
-`is_moving` | Boolean | A yes/no value indicating if the arrow board is actively moving (not statically placed) as part of a mobile work zone operation. | Optional | The `is_moving` property is optional and should not be provided if it is not known if the arrow board is moving.
 `is_in_transport_position` | Boolean | A yes/no value indicating if the arrow board is in the stowed/transport position (`true`) or deployed/upright position (`false`). | Optional |
+`is_moving` (DEPRECATED) | Boolean | *This property is deprecated and will be removed in a future version; use the `is_moving` property on the [FieldDeviceCoreDetails](/spec-content/objects/FieldDeviceCoreDetails.md) instead.* A yes/no value indicating if the arrow board is actively moving (not statically placed) as part of a mobile work zone operation. | Optional | The `is_moving` property is optional and should not be provided if it is not known if the arrow board is moving.
 
 ## Used By
 Property | Object

--- a/spec-content/objects/FieldDeviceCoreDetails.md
+++ b/spec-content/objects/FieldDeviceCoreDetails.md
@@ -13,6 +13,7 @@ Name | Type | Description | Conformance | Notes
 `name` | String | A human-readable name for the field device. | Optional |
 `description` | String | A description of the field device. | Optional |
 `status_messages` | Array; [String] | A list of messages associated with the device's status, if applicable. Used to provide additional information about the status such as specific warning or error messages. | Optional | The content of this property is up to the producer.
+`is_moving` | Boolean | A yes/no value indicating if the device is actively moving (not statically placed) as part of a mobile work zone operation. | Optional | The `is_moving` property is optional and should not be provided if it is not known if the device is moving.
 `road_event_ids` | Array; [String] | A list of one or more IDs of a [RoadEventFeature](/spec-content/objects/RoadEventFeature.md) that the device is associated with. | Optional | 
 `milepost` | Number | The linear distance measured against a milepost marker along a roadway where the device is located. | Optional | 
 `make` | String | The make or manufacturer of the device. | Optional |


### PR DESCRIPTION
This PR makes two changes:

- Add optional `is_moving` property to the [FieldDeviceCoreDetails](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/FieldDeviceCoreDetails.md) object to allow representing if a device is actively moving.
- Deprecate the existing `is_moving` property on the [ArrowBoard](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/ArrowBoard.md) object, as the new `is_moving` property on the FieldDeviceCoreDetails should be used instead.

See issue #257 for background discussion.