### PR TITLE
Add notes about HybridSign static_sign_text

### DIFF
--- a/spec-content/objects/HybridSign.md
+++ b/spec-content/objects/HybridSign.md
@@ -9,7 +9,7 @@ Name | Type | Description | Conformance | Notes
 `core_details` | [FieldDeviceCoreDetails](/spec-content/objects/FieldDeviceCoreDetails.md) | The core details of the field device shared by all field devices types, not specific to hybrid signs. | Required | This property appears on all field devices.
 `dynamic_message_function` | [HybridSignDynamicMessageFunction](/spec-content/enumerated-types/HybridSignDynamicMessageFunction.md) | The function the dynamic message displayed (e.g. a speed limit). | Required |
 `dynamic_message_text` | String | A text representation of the message currently posted to the electronic component of the hybrid sign. | Optional |
-`static_sign_text` | String | The static text on the non-electronic component of the hybrid sign. | Optional |
+`static_sign_text` | String | The static text on the non-electronic component of the hybrid sign. | Optional | This property is currently optional, but it is advisable to provide it and will be required in a future release.
 
 ## Used By
 Property | Object


### PR DESCRIPTION
Inspired by #275, this PR adds notes to the [HybridSign](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/HybridSign.md) `static_sign_text` property indicating that it is advisable to provide it and it will be required in a future release.

