### PR TITLE
Clarify usage of update date

### DIFF
--- a/schemas/4.1/RoadEventFeature.json
+++ b/schemas/4.1/RoadEventFeature.json
@@ -329,7 +329,7 @@
           "format": "date-time"
         },
         "update_date": {
-          "description": "The UTC date and time (formatted according to RFC 3339, Section 5.6) when the road event was last updated (e.g. 2020-11-03T19:37:00Z)",
+          "description": "The UTC date and time (formatted according to RFC 3339, Section 5.6) when any information in the RoadEventFeature (including child objects) that the RoadEventCoreDetails applies to was most recently updated or confirmed as up to date",
           "type": "string",
           "format": "date-time"
         }

--- a/schemas/4.1/SwzDeviceFeed.json
+++ b/schemas/4.1/SwzDeviceFeed.json
@@ -107,7 +107,7 @@
           "$ref": "#/definitions/FieldDeviceStatus"
         },
         "update_date": {
-          "description": "The UTC date and time (formatted according to RFC 3339, Section 5.6) when the field device data was last updated (e.g. 2020-11-03T19:37:00Z)",
+          "description": "The UTC date and time (formatted according to RFC 3339, Section 5.6) when any information in the FieldDeviceFeature (including child objects) that the FieldDeviceCoreDetails applies to was most recently updated or confirmed as up to date",
           "type": "string",
           "format": "date-time"
         },

--- a/spec-content/objects/FieldDeviceCoreDetails.md
+++ b/spec-content/objects/FieldDeviceCoreDetails.md
@@ -8,7 +8,8 @@ Name | Type | Description | Conformance | Notes
 `data_source_id` | String | Identifies the data source from which the field device data originates. | Required | The value must match to the `data_source_id` property of a [FeedDataSource](/spec-content/objects/FeedDataSource.md) included within the same [SwzDeviceFeed](/spec-content/objects/SwzDeviceFeed.md) GeoJSON document.
 `road_names` | Array; [String] | A list of publicly known names of the road on which the device is located. This may include the road number designated by a jurisdiction such as a county, state or interstate (e.g. I-5, VT 133). | Required |
 `device_status` | [FieldDeviceStatus](/spec-content/enumerated-types/FieldDeviceStatus.md) | The operational status of the field device. The value of this property indicates if the device is ok or in an error or warning state. | Required |
-`update_date` | String; [date-time](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.1) | The UTC time and date when the field device information was updated. | Required |
+`update_date` | String; [date-time](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.1) | The UTC date and time when any information in the [FieldDeviceFeature](/spec-content/objects/FieldDeviceFeature.md) (including child objects) that the FieldDeviceCoreDetails applies to was most recently updated or confirmed as up to date.
+ | Required |
 `has_automatic_location` | Boolean | A yes/no value indicating if the field device location (parent FieldDeviceFeature's `geometry`) is determined automatically from an onboard GPS (`true`) or manually set/overidden (`false`). | Required |
 `name` | String | A human-readable name for the field device. | Optional |
 `description` | String | A description of the field device. | Optional |

--- a/spec-content/objects/RoadEventCoreDetails.md
+++ b/spec-content/objects/RoadEventCoreDetails.md
@@ -11,8 +11,7 @@ Name | Type | Description | Conformance | Notes
 `relationship` | [Relationship](/spec-content/objects/Relationship.md) | Identifies both sequential and hierarchical relationships between the road events and other entities. For example, a relationship can be used to link multiple road events to a common 'parent', such as a project or phase, or identify a sequence of road events | Optional | 
 `description` | String | Short free text description of road event. | Optional | 
 `creation_date` | String; [date-time](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.1) | The UTC time and date when the activity or event was created. | Optional | All datetime formats shall follow [RFC 3339 Section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Example: `2016-11-03T19:37:00Z`.
-`update_date` | String; [date-time](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.1) | The UTC date and time when any information in the [RoadEventFeature](/spec-content/objects/RoadEventFeature.md) (including child objects) that the RoadEventCoreDetails applies to was most recently updated or confirmed as up to date.
- | Optional | All datetime formats shall follow [RFC 3339 Section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Example: `2016-11-03T19:37:00Z`.
+`update_date` | String; [date-time](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.1) | The UTC date and time when any information in the [RoadEventFeature](/spec-content/objects/RoadEventFeature.md) (including child objects) that the RoadEventCoreDetails applies to was most recently updated or confirmed as up to date. | Optional | All datetime formats shall follow [RFC 3339 Section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Example: `2016-11-03T19:37:00Z`.
 
 ## Used By
 Property | Object

--- a/spec-content/objects/RoadEventCoreDetails.md
+++ b/spec-content/objects/RoadEventCoreDetails.md
@@ -11,7 +11,8 @@ Name | Type | Description | Conformance | Notes
 `relationship` | [Relationship](/spec-content/objects/Relationship.md) | Identifies both sequential and hierarchical relationships between the road events and other entities. For example, a relationship can be used to link multiple road events to a common 'parent', such as a project or phase, or identify a sequence of road events | Optional | 
 `description` | String | Short free text description of road event. | Optional | 
 `creation_date` | String; [date-time](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.1) | The UTC time and date when the activity or event was created. | Optional | All datetime formats shall follow [RFC 3339 Section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Example: `2016-11-03T19:37:00Z`.
-`update_date` | String; [date-time](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.1) | The UTC time and date when the activity or event was updated. | Optional | All datetime formats shall follow [RFC 3339 Section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Example: `2016-11-03T19:37:00Z`.
+`update_date` | String; [date-time](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.1) | The UTC date and time when any information in the [RoadEventFeature](/spec-content/objects/RoadEventFeature.md) (including child objects) that the RoadEventCoreDetails applies to was most recently updated or confirmed as up to date.
+ | Optional | All datetime formats shall follow [RFC 3339 Section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Example: `2016-11-03T19:37:00Z`.
 
 ## Used By
 Property | Object


### PR DESCRIPTION
This PR resolves #184 by updating the description of the `update_date` property on the [RoadEventCoreDetails](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RoadEventCoreDetails.md) and [FieldDeviceCoreDetails](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/FieldDeviceCoreDetails.md) objects to provide more clarity on when to change and how to use the `update_date`.


