### PR TITLE
Adding undefined and unknown values

### DIFF
--- a/spec-content/enumerated-types/Direction.md
+++ b/spec-content/enumerated-types/Direction.md
@@ -8,6 +8,8 @@ Value | Description
 `eastbound` | Road flow is in the eastbound direction
 `southbound` | Road flow is in the southbound direction
 `westbound` | Road flow is in the westbound direction
+`undefined` | Used if a data producer has start and end location for a road, but the road doesn't have a direction. Allows data consumers to assume that first coordinate is the start of an actual work zone.
+`unknown` | 	Used if a data producer doesn't know for sure which direction of travel is affected (including on a roadway with signed directions). Create an event for each direction and use the `unknown` enumeration. The data consumer cannot safely assume that work is affecting this direction of travel.
 
 ## Used By
 Property | Object


### PR DESCRIPTION
This PR resolves #229 by adding `undefined` and `unknown` to the [Direction](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/enumerated-types/Direction.md) enumerated types of the [RoadEventCoreDetail](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RoadEventCoreDetails.md#roadeventcoredetails-object)s to allow for no road direction or if the producer does not know affected direction of travel.