### PR TITLE
Adding no-passing to RestrictionType

### DIFF
--- a/schemas/4.1/RoadEventFeature.json
+++ b/schemas/4.1/RoadEventFeature.json
@@ -534,7 +534,8 @@
         "gross-weight-limit",
         "towing-prohibited",
         "permitted-oversize-loads-prohibited",
-        "local-access-only"
+        "local-access-only",
+        "no-passing"
       ]
     },
     "WorkTypeName": {

--- a/spec-content/enumerated-types/RestrictionType.md
+++ b/spec-content/enumerated-types/RestrictionType.md
@@ -18,6 +18,7 @@ Value | Description
 `gross-weight-limit` | Vehicle gross-weight-limit restrictions reduced along the segment being described.
 `towing-prohibited` | Towing prohibited along the segment being described.
 `permitted-oversize-loads-prohibited` | “Permitted oversize loads” prohibited along the segment being described; this applies to annual oversize load permits.
+`no-passing` | The passing lane is no longer available for use.
 
 ## Used By
 Property | Object

--- a/spec-content/enumerated-types/RestrictionType.md
+++ b/spec-content/enumerated-types/RestrictionType.md
@@ -18,7 +18,7 @@ Value | Description
 `gross-weight-limit` | Vehicle gross-weight-limit restrictions reduced along the segment being described.
 `towing-prohibited` | Towing prohibited along the segment being described.
 `permitted-oversize-loads-prohibited` | “Permitted oversize loads” prohibited along the segment being described; this applies to annual oversize load permits.
-`no-passing` | The passing lane is no longer available for use.
+`no-passing` | Crossing the center line markings for passing is prohibited.
 
 ## Used By
 Property | Object


### PR DESCRIPTION
Per Issue #215, this adds `no-passing` as a value to the [RestrictionType](https://github.com/usdot-jpo-ode/wzdx/blob/feature/no-passing-restriction/spec-content/enumerated-types/RestrictionType.md#restrictiontype-enumerated-type) enumerated type.