### PR TITLE
Fix plural "right-chevrons" typo in schema

### DIFF
--- a/schemas/4.0/SwzDeviceFeed.json
+++ b/schemas/4.0/SwzDeviceFeed.json
@@ -532,9 +532,9 @@
         "right-arrow-flashing",
         "right-arrow-sequential",
         "right-arrow-static",
-        "right-chevrons-flashing",
-        "right-chevrons-sequential",
-        "right-chevrons-static",
+        "right-chevron-flashing",
+        "right-chevron-sequential",
+        "right-chevron-static",
         "unknown"
       ]
     },


### PR DESCRIPTION
This PR resolves #305 by changing "right-chevrons" to "right-chevron" (removing "s") in the JSON Schema for the SwzDeviceFeed ArrowBoardPattern.

Per [this commit](https://github.com/usdot-jpo-ode/wzdx/pull/208/commits/921fc8a37a31f0bb558e07204d18b8133e05c03d) and the [ArrowBoardPattern markdown documentation file](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/enumerated-types/ArrowBoardPattern.md), "chevron" should be singular.

