### PR TITLE
Allow specifying the sign text for a Flashing Beacon

### DIFF
--- a/schemas/4.1/SwzDeviceFeed.json
+++ b/schemas/4.1/SwzDeviceFeed.json
@@ -316,6 +316,10 @@
             "is_flashing": {
               "type": "boolean",
               "description": "A yes/no value indicating if the flashing beacon is currently in use and flashing"
+            },
+            "sign_text": {
+              "type": "string",
+              "description": "The text on the sign the beacon is mounted on, if applicable"
             }
           },
           "required": [

--- a/spec-content/objects/FlashingBeacon.md
+++ b/spec-content/objects/FlashingBeacon.md
@@ -9,6 +9,7 @@ Name | Type | Description | Conformance | Notes
 `core_details` | [FieldDeviceCoreDetails](/spec-content/objects/FieldDeviceCoreDetails.md) | The core details of the field device that are shared by all types of field devices, not specific to flashing beacons. | Required | This property appears on all field devices.
 `function` | [FlashingBeaconFunction](/spec-content/enumerated-types/FlashingBeaconFunction.md) | Describes the function or purpose of the flashing beacon, i.e. what it is being used to indicate. | Required |
 `is_flashing` | Boolean | A yes/no value indicating if the flashing beacon is currently in use and flashing. | Optional | The `is_flashing` property is optional as it should not be provided if the producer does not know if the beacon is flashing (e.g. if it's in error state or similar).
+`sign_text` | String | The text on the sign the beacon is mounted on, if applicable. | Optional |
 
 ## Used By
 Property | Object


### PR DESCRIPTION
This PR resolves #295 by adding an optional `sign_text` property to the [FlashingBeacon](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/FlashingBeacon.md) object which allows a producer to provide the text on the sign the beacon is mounted on, if applicable.