### PR TITLE
Allow providing field device without providing a road name

### DIFF
--- a/schemas/4.1/SwzDeviceFeed.json
+++ b/schemas/4.1/SwzDeviceFeed.json
@@ -95,14 +95,6 @@
           "description": "Identifies the data source from which the field device information is sourced from",
           "type": "string"
         },
-        "road_names": {
-          "description": "A list of publicly known names of the road on which the field device is located. This may include the road number designated by a jurisdiction such as a county, state or interstate (e.g. I-5, VT 133)",
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "string"
-          }
-        },
         "device_status": {
           "$ref": "#/definitions/FieldDeviceStatus"
         },
@@ -114,6 +106,14 @@
         "has_automatic_location": {
           "description": "A yes/no value indicating if the field device location (parent FieldDeviceFeature's geometry) is determined automatically from an onboard GPS (true) or manually set/overidden (false)",
           "type": "boolean"
+        },
+        "road_names": {
+          "description": "A list of publicly known names of the road on which the field device is located. This may include the road number designated by a jurisdiction such as a county, state or interstate (e.g. I-5, VT 133)",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
         },
         "name": {
           "type": "string",
@@ -161,7 +161,6 @@
       "required": [
         "device_type",
         "data_source_id",
-        "road_names",
         "device_status",
         "update_date",
         "has_automatic_location"

--- a/spec-content/objects/FieldDeviceCoreDetails.md
+++ b/spec-content/objects/FieldDeviceCoreDetails.md
@@ -6,10 +6,10 @@ Name | Type | Description | Conformance | Notes
 --- | --- | --- | --- | ---
 `device_type` | [FieldDeviceType](/spec-content/enumerated-types/FieldDeviceType.md) | The type of field device. | Required |
 `data_source_id` | String | Identifies the data source from which the field device data originates. | Required | The value must match to the `data_source_id` property of a [FeedDataSource](/spec-content/objects/FeedDataSource.md) included within the same [SwzDeviceFeed](/spec-content/objects/SwzDeviceFeed.md) GeoJSON document.
-`road_names` | Array; [String] | A list of publicly known names of the road on which the device is located. This may include the road number designated by a jurisdiction such as a county, state or interstate (e.g. I-5, VT 133). | Required |
 `device_status` | [FieldDeviceStatus](/spec-content/enumerated-types/FieldDeviceStatus.md) | The operational status of the field device. The value of this property indicates if the device is ok or in an error or warning state. | Required |
 `update_date` | String; [date-time](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.1) | The UTC time and date when the field device information was updated. | Required |
 `has_automatic_location` | Boolean | A yes/no value indicating if the field device location (parent FieldDeviceFeature's `geometry`) is determined automatically from an onboard GPS (`true`) or manually set/overidden (`false`). | Required |
+`road_names` | Array; [String] | A list of publicly known names of the road on which the device is located. This may include the road number designated by a jurisdiction such as a county, state or interstate (e.g. I-5, VT 133). | Optional |
 `name` | String | A human-readable name for the field device. | Optional |
 `description` | String | A description of the field device. | Optional |
 `status_messages` | Array; [String] | A list of messages associated with the device's status, if applicable. Used to provide additional information about the status such as specific warning or error messages. | Optional | The content of this property is up to the producer.


### PR DESCRIPTION
This PR is based on #287 and makes a simple modification of changing the conformance of the `road_names` property on the [FieldDeviceCoreDetails](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/FieldDeviceCoreDetails.md) from "Required" to "Optional".

This allows producers of a SwzDeviceFeed to provide a field device without having to try to determine the name of the road it is deployed on, simplifying manual entry or internal processes for producers.