### PR TITLE
Allow LocationMarker to mark any delineation point in a work zone

### DIFF
--- a/schemas/4.1/SwzDeviceFeed.json
+++ b/schemas/4.1/SwzDeviceFeed.json
@@ -571,6 +571,7 @@
       "description": "Options for what a MarkedLocation can mark, such as the start or end of a road event",
       "enum": [
         "afad",
+        "delineator",
         "flagger",
         "lane-shift",
         "lane-closure",

--- a/spec-content/enumerated-types/MarkedLocationType.md
+++ b/spec-content/enumerated-types/MarkedLocationType.md
@@ -5,6 +5,7 @@ The `MarkedLocationType` enumerated type describes options for what a [MarkedLoc
 Value | Description
 --- | ---
 `afad` | An automatic flagger assistance device.
+`delineator` | A generic delineation point in a work zone. This value can be used for most types of marked locations that don't match any of the other values.
 `flagger` | A human who is directing traffic.
 `lane-shift` | A lane shift.
 `lane-closure` | One or more lanes are closed.


### PR DESCRIPTION
This PR resolves #244 and supersedes #227. 

The proposed changes allow a [LocationMarker](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/LocationMarker.md) to mark any delineation point in a work zone, such an intermediate point—a cone, a barrier, etc.

Specifically, the following changes were made:

- Add generic `delineator` value to the [MarkedLocationType](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/enumerated-types/MarkedLocationType.md) enumerated type.