### PR TITLE
Rename center-left-turn-lane to be general to support more users

### DIFF
--- a/examples/WZDxFeed/local_access_only_bidirectional_linestring_example.geojson
+++ b/examples/WZDxFeed/local_access_only_bidirectional_linestring_example.geojson
@@ -117,7 +117,7 @@
           {
             "order": 1,
             "status": "open",
-            "type": "center-left-turn-lane",
+            "type": "two-way-center-turn-lane",
             "restrictions": [
               {
                 "type": "local-access-only"

--- a/schemas/4.1/RoadEventFeature.json
+++ b/schemas/4.1/RoadEventFeature.json
@@ -572,6 +572,7 @@
         "shoulder",
         "parking",
         "median",
+        "two-way-center-turn-lane",
         "center-left-turn-lane"
       ]
     },

--- a/spec-content/enumerated-types/LaneType.md
+++ b/spec-content/enumerated-types/LaneType.md
@@ -14,7 +14,8 @@ Value | Description
 `shoulder` | A portion of the roadway that is outside (either right or left) of the main travel lanes. A shoulder can have many uses but is not intended for general traffic.
 `parking` | A lane used for parking, not allowed for travel.
 `median` | An often unpaved, non-drivable area that separates sections of the roadway. In most cases a median should only be described if it separates lanes in a single direction of travel, as per [business rule #1](/Creating_a_WZDx_Feed.md#business-rules) each direction of travel must be represented by a separate road event.
-`center-left-turn-lane` | A lane in the center of a bidirectional roadway that traffic from both directions uses to make a left turn.
+`two-way-center-turn-lane` | A lane in the center of a bidirectional roadway that traffic from both directions uses to make a turn that crosses opposite direction of traffic (i.e. left in right-side driving countries, and right in left-side driving countries).
+`center-left-turn-lane` (DEPRECATED) | A lane in the center of a bidirectional roadway that traffic from both directions uses to make a left turn. *This property is deprecated and will be removed in a future release, use `two-way-center-turn-lane` instead.*
 
 ## Used By
 Property | Object


### PR DESCRIPTION
This PR resolves #234.

The following changes are proposed:

- Deprecate the `center-left-turn-lane` value on the [LaneType](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/enumerated-types/LaneType.md) enumerated type.
- Add `two-way-center-turn-lane` value to the LaneType enumerated type.