### PR TITLE
4.1 update incident type enumeration winds

### DIFF
--- a/spec-content/enumerated-types/IncidentType_Wind.md
+++ b/spec-content/enumerated-types/IncidentType_Wind.md
@@ -1,10 +1,3 @@
-## Summary
-- This requests supports #318 
-- The Wind enumeration fills the `type_of_incident` property to let drives know why a road has been detoured, restricted, or closed. 
-
-## Motivation
-Adding the `type_of_incident` property to the IncidentRoadEvent object lets data publishers tell drivers why road access has been detoured, restricted, or closed. Further, implementing this property adds value to road event feeds by reducing driver uncertainty.
-
 # IncidentType_Wind Enumerated Type
 Values describe events that have detoured, restricted, or closed a road.
 

--- a/spec-content/enumerated-types/IncidentType_Wind.md
+++ b/spec-content/enumerated-types/IncidentType_Wind.md
@@ -1,0 +1,29 @@
+## Summary
+- This requests supports #318 
+- The Wind enumeration fills the `type_of_incident` property to let drives know why a road has been detoured, restricted, or closed. 
+
+## Motivation
+Adding the `type_of_incident` property to the IncidentRoadEvent object lets data publishers tell drivers why road access has been detoured, restricted, or closed. Further, implementing this property adds value to road event feeds by reducing driver uncertainty.
+
+# IncidentType_Wind Enumerated Type
+Values describe events that have detoured, restricted, or closed a road.
+
+## Values
+Value | Description
+--- | ---
+`Calm` | Calm, operations normal. (windspeed: <1 mph / <1 km/h)
+`Light Winds` | Light winds may interrupt normal operations. (windspeed: 1-12 mph / 1-19 km/h)
+`Moderate Winds` | Moderate winds may interrupt normal operations. (windspeed: 13-18 mph / 20-28 km/h)
+`Windy` | Conditions are windy. Use Caution. (windspeed: 19-24 mph / 29-38 km/h)
+`Strong Winds` | Strong winds interrupt normal operations. (windspeed: 25-38 mph / 39-61 km/h)
+`Gale Force Winds` | Gale force winds interrupt normal operations. (windspeed: 39-54 mph / 62-88 km/h)
+`Storm Force Winds/Tropical Storm` | Storm force winds or a tropical storm interrupts normal operations. (windspeed: 55-72 mph / 89-117 km/h)
+`Hurricane Force Winds/Hurricane` | Hurricane force winds or a hurricane interrupts normal operations. (windspeed: >73 mph / >117 km/h)
+`Tornado` | A tornado interrupts normal operations. 
+`Crosswinds` | Crosswinds interrupt normal operations.
+`Gusty` | Winds	Gusty winds interrupt normal operations.
+
+## Used By
+Property | Object
+--- | ---
+`type_of_incident` | [IncidentRoadEvent](/spec-content/objects/IncidentRoadEvent.md)

--- a/spec-content/objects/RestrictionRoadEvent.md
+++ b/spec-content/objects/RestrictionRoadEvent.md
@@ -11,6 +11,7 @@ Name | Type | Description | Conformance | Notes
 `core_details` | [RoadEventCoreDetails](/spec-content/objects/RoadEventCoreDetails.md) | Describes the basic characterisitics of a road event.  | Required |
 `restrictions` | Array; [[Restriction](/spec-content/objects/Restriction.md)] | A list of zero or more road restrictions that apply to the roadway segment described by this road event. | Conditional: required if `lanes` property is not provided. | Restrictions can also be provided on an individual lane.
 `lanes` | Array; \[[Lane](/spec-content/objects/Lane.md)\] | A list of individual lanes within a road event (roadway segment). | Conditional: required if `restrictions` property is not provided. |
+`vehicle_impact` | [VehicleImpact](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/enumerated-types/VehicleImpact.md) | The impact to vehicular lanes along a single road in a single direction. | Required |
 
 ## Used By
 Property | Object


### PR DESCRIPTION
## Summary
- This requests supports #318 
- The Wind enumeration fills the `type_of_incident` property to let drives know why a road has been detoured, restricted, or closed. 

## Motivation
Adding the `type_of_incident` property to the IncidentRoadEvent object lets data publishers tell drivers why road access has been detoured, restricted, or closed. Further, implementing this property adds value to road event feeds by reducing driver uncertainty.

# IncidentType_Wind Enumerated Type
Values describe events that have detoured, restricted, or closed a road.

## Values
Value | Description
--- | ---
`Calm` | Calm, operations normal. (windspeed: <1 mph / <1 km/h)
`Light Winds` | Light winds may interrupt normal operations. (windspeed: 1-12 mph / 1-19 km/h)
`Moderate Winds` | Moderate winds may interrupt normal operations. (windspeed: 13-18 mph / 20-28 km/h)
`Windy` | Conditions are windy. Use Caution. (windspeed: 19-24 mph / 29-38 km/h)
`Strong Winds` | Strong winds interrupt normal operations. (windspeed: 25-38 mph / 39-61 km/h)
`Gale Force Winds` | Gale force winds interrupt normal operations. (windspeed: 39-54 mph / 62-88 km/h)
`Storm Force Winds/Tropical Storm` | Storm force winds or a tropical storm interrupts normal operations. (windspeed: 55-72 mph / 89-117 km/h)
`Hurricane Force Winds/Hurricane` | Hurricane force winds or a hurricane interrupts normal operations. (windspeed: >73 mph / >117 km/h)
`Tornado` | A tornado interrupts normal operations. 
`Crosswinds` | Crosswinds interrupt normal operations.
`Gusty` | Winds	Gusty winds interrupt normal operations.

## Used By
Property | Object
--- | ---
`type_of_incident` | [IncidentRoadEvent](/spec-content/objects/IncidentRoadEvent.md)