### PR TITLE
Update RestrictionType.md to include road restrictions such as reduced-speed, shift-left, and shift-right

### DIFF
--- a/spec-content/enumerated-types/RestrictionType.md
+++ b/spec-content/enumerated-types/RestrictionType.md
@@ -18,6 +18,10 @@ Value | Description
 `gross-weight-limit` | Vehicle gross-weight-limit restrictions reduced along the segment being described.
 `towing-prohibited` | Towing prohibited along the segment being described.
 `permitted-oversize-loads-prohibited` | “Permitted oversize loads” prohibited along the segment being described; this applies to annual oversize load permits.
+`reduced-speed` | Vehicle must travel at a reduced speed compared to posted speed limit along the segment being described.
+`shift-left` | Vehicle must shift left by at least one lane along the segment being described.
+`shift-right` | Vehicle must shift right by at least one lane along the segment being described.
+
 
 ## Used By
 Property | Object


### PR DESCRIPTION
##  [RestrictionType Enumerated Type](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/enumerated-types/RestrictionType.md)

### Summary of Changes
Added road restrictions to handle situations where vehicles are required to reduce their speed or shift lanes in order to avoid roadside hazards.

### Impact of Changes
A [RestrictionRoadEvent](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RestrictionRoadEvent.md) can now be created to warn drivers about restrictions placed on a particular roadway to ensure their safety due to roadside hazards such as a vegetable oil spill, objects which can puncture tires such as nails or screws, first-responders parked on the side of the road in response to an accident scene, or the presence of black ice on a roadway.

### Enhanced Information about Changes

The parent [Restriction](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/Restriction.md) object contains an optional "Number" field which can be used to indicate the number of lanes a vehicle must shift-left or shift-right, or the number of MPH at which a vehicle must drive as a reduced speed. Thus, the simple restriction types of shift-left, shift-right, and reduced-speed can be enhanced with information specific enough for drivers to alter their behavior.