### PR TITLE
Change traffic sensor traffic data properties from Integer to Number value type (refactor to 4.1)

### DIFF
--- a/schemas/4.1/SwzDeviceFeed.json
+++ b/schemas/4.1/SwzDeviceFeed.json
@@ -323,7 +323,7 @@
             "function"
           ]
         }
-      ]    
+      ]
     },
     "HybridSign": {
       "title": "Hybrid Sign Field Device",
@@ -450,17 +450,17 @@
               "description": "The UTC date and time where the TrafficSensor data collection ended. The averages and totals contained in the TrafficSensor data apply to the inclusive interval of 'collection_interval_start_date' to 'collection_interval_end_date'"
             },
             "average_speed_kph": {
-              "type": "integer",
+              "type": "number",
               "minimum": 0,
               "description": "The average speed of vehicles across all lanes over the collection interval in kilometers per hour"
             },
             "volume_vph": {
-              "type": "integer",
+              "type": "number",
               "minimum": 0,
               "description": "The rate of vehicles passing by the sensor during the collection interval in vehicles per hour"
             },
             "occupancy_percent": {
-              "type": "integer",
+              "type": "number",
               "minimum": 0,
               "description": "The percent of time the roadway section monitored by the sensor was occupied by a vehicle over the collection interval"
             },
@@ -493,17 +493,17 @@
           "description": "The lane's position in sequence within the road event specified by the 'road_event_id' property"
         },
         "average_speed_kph": {
-          "type": "integer",
-          "minimum": 1,
+          "type": "number",
+          "minimum": 0,
           "description": "The average speed of traffic in the lane over the collection interval (in kilometers per hour)"
         },
         "volume_vph": {
-          "type": "integer",
+          "type": "number",
           "minimum": 0,
           "description": "The rate of vehicles passing by the sensor in the lane during the collection interval (in vehicles per hour)"
         },
         "occupancy_percent": {
-          "type": "integer",
+          "type": "number",
           "minimum": 0,
           "description": "The percent of time the lane monitored by the sensor was occupied by a vehicle over the collection interval"
         }

--- a/spec-content/objects/TrafficSensor.md
+++ b/spec-content/objects/TrafficSensor.md
@@ -3,18 +3,18 @@ The `TrafficSensor` object describes a traffic sensor deployed on a roadway whic
 
 The `TrafficSensor` is a type of field device; it has a `core_details` property which contains the [FieldDeviceCoreDetails](/spec-content/objects/FieldDeviceCoreDetails.md) and exists within a [FieldDeviceFeature](/spec-content/objects/FieldDeviceFeature.md).
 
-## Properties 
+## Properties
 Name | Type | Description | Conformance | Notes
 --- | --- | --- | --- | ---
 `core_details` | [FieldDeviceCoreDetails](/spec-content/objects/FieldDeviceCoreDetails.md) | The core details of the field device shared by all field devices types, not specific to traffic sensors. | Required | This property appears on all field devices.
 `collection_interval_start_date` | String; [date-time](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.1) | The UTC date and time where the `TrafficSensor` data began being collected at. The averages and totals contained in the `TrafficSensor` data apply to the inclusive interval of `collection_interval_start_date` to `collection_interval_end_date`. | Required |
 `collection_interval_end_date` | String; [date-time](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.3.1) | The UTC date and time where the `TrafficSensor` collection interval ended. The averages and totals contained in the `TrafficSensor` data apply to the inclusive interval of `collection_interval_start_date` to `collection_interval_end_date`. | Required |
-`average_speed_kph` | Integer (>= 0) | The average speed of vehicles across all lanes over the collection interval in kilometers per hour. | Optional | 
-`volume_vph` | Integer (>= 0) | The rate of vehicles passing by the sensor during the collection interval in vehicles per hour. | Optional |
-`occupancy_percent` | Integer (>= 0) | The percent of time the roadway section monitored by the sensor was occupied by a vehicle over the collection interval. | Optional |
+`average_speed_kph` | Number (>= 0) | The average speed of vehicles across all lanes over the collection interval in kilometers per hour. | Optional |
+`volume_vph` | Number (>= 0) | The rate of vehicles passing by the sensor during the collection interval in vehicles per hour. | Optional |
+`occupancy_percent` | Number (>= 0) | The percent of time the roadway section monitored by the sensor was occupied by a vehicle over the collection interval. | Optional |
 `lane_data` | Array; [[TrafficSensorLaneData](/spec-content/objects/TrafficSensorLaneData.md)] | A list of objects each describing traffic data for a specific lane—each pointing to a road event lane and indiciating the metrics of that lane. | Optional | Lane-level data can only be provided if the data producer has knowledge of the road event to assign the traffic sensor lane data to.
 
 ## Used By
 Property | Object
---- | --- 
+--- | ---
 `properties` | [FieldDeviceFeature](/spec-content/objects/FieldDeviceFeature.md)

--- a/spec-content/objects/TrafficSensorLaneData.md
+++ b/spec-content/objects/TrafficSensorLaneData.md
@@ -8,11 +8,11 @@ Name | Type | Description | Conformance | Notes
 --- | --- | --- | --- | ---
 `road_event_id` | String | The ID of a [RoadEventFeature](/spec-content/objects/RoadEventFeature.md) which the measured lane occurs in. | Required |
 `lane_order` | Positive Integer | The lane's position in sequence within the road event (specified by `road_event_id`). The value of this property corresponds to the associated road event's [Lane](/spec-content/objects/Lane.md)'s `order` property. | Required |
-`average_speed_kph` | Integer (>= 0) | The average speed of traffic in the lane over the collection interval (in kilometers per hour). | Optional |
-`volume_vph` | Integer (>= 0) | The rate of vehicles passing by the sensor in the lane during the collection interval (in vehicles per hour). | Optional | 
-`occupancy_percent` | Integer (>= 0) | The percent of time the lane monitored by the sensor was occupied by a vehicle over the collection interval. | Optional |
+`average_speed_kph` | Number (>= 0) | The average speed of traffic in the lane over the collection interval (in kilometers per hour). | Optional |
+`volume_vph` | Number (>= 0) | The rate of vehicles passing by the sensor in the lane during the collection interval (in vehicles per hour). | Optional |
+`occupancy_percent` | Number (>= 0) | The percent of time the lane monitored by the sensor was occupied by a vehicle over the collection interval. | Optional |
 
 ## Used By
 Property | Object
---- | --- 
+--- | ---
 `lane_data` | [TrafficSensor](/spec-content/objects/TrafficSensor.md)


### PR DESCRIPTION
Fix - Use Number not Integer for higher precision, applies to average_speed_kph / volume_vph / occupancy_percent of TrafficSensor / TrafficSensorLaneData

Fix for IS #219 
Replaces PR #228 to reference schemas/4.1/SwzDeviceFeed.json 