### PR TITLE
Remove "used by TDx" notes from obj and enum files

### DIFF
--- a/spec-content/enumerated-types/Direction.md
+++ b/spec-content/enumerated-types/Direction.md
@@ -17,8 +17,6 @@ Property | Object
 `direction` | [RoadEventCoreDetails](/spec-content/objects/RoadEventCoreDetails.md)
 `road_direction` | [FieldDeviceCoreDetails](/spec-content/objects/FieldDeviceCoreDetails.md)
 
-The `Direction` enumerated type is also used in the [TDx Specification](https://github.com/usdot-jpo-ode/TDx).
-
 ## Additional Information
 The `Direction` enumerated type values were based on the TMDD Link-alignment Enumeration, which contains the following values:
 

--- a/spec-content/enumerated-types/LaneStatus.md
+++ b/spec-content/enumerated-types/LaneStatus.md
@@ -16,5 +16,3 @@ Value | Description
 Property | Object
 --- | ---
 `status` | [Lane](/spec-content/objects/Lane.md)
-
-The `LaneStatus` enumerated type is also used by the [TDx Lane](https://github.com/usdot-jpo-ode/TDx/blob/main/spec-content/objects/Lane.md).

--- a/spec-content/enumerated-types/LaneType.md
+++ b/spec-content/enumerated-types/LaneType.md
@@ -22,8 +22,6 @@ Property | Object
 --- | ---
 `type` | [Lane](/spec-content/objects/Lane.md)
 
-The `LaneType` enumerated type is also used by the [TDx Lane](https://github.com/usdot-jpo-ode/TDx/blob/main/spec-content/objects/Lane.md).
-
 ## Additional Information
 The LaneType enumerated type was originally based on the TMDD LaneRoadway Enumeration, which is imported into TMDD from SAE 2540 (ITIS Standard).
 

--- a/spec-content/enumerated-types/RestrictionType.md
+++ b/spec-content/enumerated-types/RestrictionType.md
@@ -24,5 +24,3 @@ Value | Description
 Property | Object
 --- | ---
 `type` | [Restriction](/spec-content/objects/Restriction.md)
-
-The `RestrictionType` enumerated type is also used by the [TDx Restriction](https://github.com/usdot-jpo-ode/TDx/blob/main/spec-content/objects/Restriction.md).

--- a/spec-content/enumerated-types/UnitOfMeasurement.md
+++ b/spec-content/enumerated-types/UnitOfMeasurement.md
@@ -15,5 +15,3 @@ Value | Description
 Property | Object
 --- | ---
 `unit` | [Restriction](/spec-content/objects/Restriction.md)
-
-The `UnitOfMeasurement` enumerated type is also used in the [TDx Specification](https://github.com/usdot-jpo-ode/TDx). 

--- a/spec-content/enumerated-types/VehicleImpact.md
+++ b/spec-content/enumerated-types/VehicleImpact.md
@@ -21,5 +21,3 @@ Value | Description
 Property | Object
 --- | ---
 `vehicle_impact` | [WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md)
-
-The `VehicleImpact` enumerated type is also used by road events defined in the [TDx Specification](https://github.com/usdot-jpo-ode/TDx). 

--- a/spec-content/objects/Lane.md
+++ b/spec-content/objects/Lane.md
@@ -14,5 +14,3 @@ Name | Type | Description | Conformance | Notes
 Property | Object
 --- | ---
 `lanes` | [WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md)
-
-This object is also used in the [TDx RestrictionRoadEvent](https://github.com/usdot-jpo-ode/TDx/blob/main/spec-content/objects/RestrictionRoadEvent.md). 

--- a/spec-content/objects/Restriction.md
+++ b/spec-content/objects/Restriction.md
@@ -13,5 +13,3 @@ Property | Object
 --- | ---
 `restrictions` | [WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md)
 `restrictions` | [Lane](/spec-content/objects/Lane.md)
-
-This object is also used by the [TDx RestrictionRoadEvent](https://github.com/usdot-jpo-ode/TDx/blob/main/spec-content/objects/RestrictionRoadEvent.md). 

--- a/spec-content/objects/RoadEventCoreDetails.md
+++ b/spec-content/objects/RoadEventCoreDetails.md
@@ -20,5 +20,3 @@ Property | Object
 --- | ---
 `core_details` | [DetourRoadEvent](/spec-content/objects/DetourRoadEvent.md)
 `core_details` | [WorkZoneRoadEvent](/spec-content/objects/WorkZoneRoadEvent.md)
-
-The `RoadEventCoreDetails` object is also used by road events defined in the [TDx Specification](https://github.com/usdot-jpo-ode/TDx). 

--- a/spec-content/objects/RoadEventFeature.md
+++ b/spec-content/objects/RoadEventFeature.md
@@ -14,5 +14,3 @@ Name | Type | Description | Conformance | Notes
 Property | Object
 --- | ---
 `features` | [WorkZoneFeed](/spec-content/objects/WorkZoneFeed.md)
-
-The `RoadEventFeature` object is also used for road events defined in the [TDx Specification](https://github.com/usdot-jpo-ode/TDx). 


### PR DESCRIPTION
Bring in one last edit to release/v4.1