### PR TITLE
Allow providing current velocity for a field device

### DIFF
--- a/schemas/4.2/DeviceFeed.json
+++ b/schemas/4.2/DeviceFeed.json
@@ -164,6 +164,10 @@
         "firmware_version": {
           "type": "string",
           "description": "The version of firmware the device is using to operate"
+        },
+        "velocity_kph": {
+          "type": "number",
+          "description": "The velocity of the device in kilometers per hour"
         }
       },
       "required": [

--- a/spec-content/objects/FieldDeviceCoreDetails.md
+++ b/spec-content/objects/FieldDeviceCoreDetails.md
@@ -21,6 +21,7 @@ Name | Type | Description | Conformance | Notes
 `model` | String | The model of the device. | Optional |
 `serial_number` | String | The serial number of the device. | Optional |
 `firmware_version` | String | The version of firmware the device is using to operate. | Optional |
+`velocity_kph` | Number | The velocity of the device in kilometers per hour. | Optional |
 
 ## Used By
 Property | Object


### PR DESCRIPTION
This PR enhances the WZDx Device Feed specification to allow a data producer to provide the velocity for any type of field device. Specifically, the following change was made: 

- Add new optional property `velocity_kph` to the [FieldDeviceCoreDetails](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/FieldDeviceCoreDetails.md).

This PR resolves #296.