### PR TITLE
Allow a LocationMarker to be used to mark an active work truck

### DIFF
--- a/schemas/4.2/DeviceFeed.json
+++ b/schemas/4.2/DeviceFeed.json
@@ -608,6 +608,7 @@
         "road-closure",
         "road-event-start",
         "road-event-end",
+        "work-truck-with-lights-flashing",
         "work-zone-start",
         "work-zone-end"
       ]

--- a/spec-content/enumerated-types/MarkedLocationType.md
+++ b/spec-content/enumerated-types/MarkedLocationType.md
@@ -14,6 +14,7 @@ Value | Description
 `road-closure` | The start of a closed road.
 `road-event-start` | The start point of a road event.
 `road-event-end` | The end point of a road event.
+`work-truck-with-lights-flashing` | A work truck with lights flashing, actively engaged in construction or maintenance activity on the roadway.
 `work-zone-start` | The start point of a work zone.
 `work-zone-end` | The end point of a work zone.
 `temporary-traffic-signal` (DEPRECATED) | A temporary traffic signal. *This property will be removed in a future release; use [TrafficSignal](../objects/TrafficSignal.md) instead.*


### PR DESCRIPTION
This PR resolves #298 by enhancing the [LocationMarker](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/LocationMarker.md) field device to allow it to be used to mark an active work truck. 

Specifically, the following change was made:

- Add new value `work-truck-with-lights-flashing` to the [MarkedLocationType](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/enumerated-types/MarkedLocationType.md) enumerated type.