### PR TITLE
Clarify FlashingBeacon is for representing a flashing warning beacon mounted on a temporary traffic control device

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -73,7 +73,7 @@ WZDx version 4.0 implements clean up and small additions in functionality to the
     - `ArrowBoard`: An electronic, connected arrow board which can display an arrow pattern to direct traffic.
     - `Camera`: A camera device deployed in the field, capable of capturing still images.
     - `DynamicMessageSign`: An electronic traffic sign deployed on the roadway, used to provide information to travelers.
-    - `FlashingBeacon`: A flashing beacon light of any form (e.g. trailer-mounted, vehicle), used to indicate something or capture driver attention.
+    - `FlashingBeacon`: A flashing warning beacon used to supplement a temporary traffic control device. It is mounted on a sign or channelizing device that is used to indicate a warning condition and capture driver attention.
     - `HybridSign`: A hybrid sign that contains static text (e.g. on an aluminum sign) along with a single electronic message display, used to provide information to travelers.
     - `LocationMarker`: Describes any GPS-enabled ITS device that is placed at a point on a roadway to dynamically know the location of something (often the beginning or end of a work zone).
     - `TrafficSensor`: A traffic sensor deployed on a roadway which captures traffic metrics (e.g. speed, volume, occupancy) over a collection interval.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -73,7 +73,7 @@ WZDx version 4.0 implements clean up and small additions in functionality to the
     - `ArrowBoard`: An electronic, connected arrow board which can display an arrow pattern to direct traffic.
     - `Camera`: A camera device deployed in the field, capable of capturing still images.
     - `DynamicMessageSign`: An electronic traffic sign deployed on the roadway, used to provide information to travelers.
-    - `FlashingBeacon`: A flashing warning beacon used to supplement a temporary traffic control device. It is mounted on a sign or channelizing device that is used to indicate a warning condition and capture driver attention.
+    - `FlashingBeacon`: A flashing beacon light of any form (e.g. trailer-mounted, vehicle), used to indicate something or capture driver attention.
     - `HybridSign`: A hybrid sign that contains static text (e.g. on an aluminum sign) along with a single electronic message display, used to provide information to travelers.
     - `LocationMarker`: Describes any GPS-enabled ITS device that is placed at a point on a roadway to dynamically know the location of something (often the beginning or end of a work zone).
     - `TrafficSensor`: A traffic sensor deployed on a roadway which captures traffic metrics (e.g. speed, volume, occupancy) over a collection interval.

--- a/schemas/4.2/DeviceFeed.json
+++ b/schemas/4.2/DeviceFeed.json
@@ -297,7 +297,7 @@
     },
     "FlashingBeacon": {
       "title": "Flashing Beacon Field Device",
-      "description": "A flashing beacon light of any form (e.g. trailer-mounted, vehicle), used to indicate something and capture driver attention",
+      "description": "A flashing warning beacon used to supplement a temporary traffic control device. It is mounted on a sign or channelizing device that is used to indicate a warning condition and capture driver attention",
       "allOf": [
         {
           "properties": {

--- a/schemas/4.2/DeviceFeed.json
+++ b/schemas/4.2/DeviceFeed.json
@@ -297,7 +297,7 @@
     },
     "FlashingBeacon": {
       "title": "Flashing Beacon Field Device",
-      "description": "A flashing warning beacon used to supplement a temporary traffic control device. It is mounted on a sign or channelizing device that is used to indicate a warning condition and capture driver attention",
+      "description": "A flashing warning beacon used to supplement a temporary traffic control device",
       "allOf": [
         {
           "properties": {

--- a/spec-content/README.md
+++ b/spec-content/README.md
@@ -59,7 +59,7 @@ Object | Description
 [DynamicMessagesSign](/spec-content/objects/DynamicMessageSign.md) | An electronic traffic sign deployed on the roadway, used to provide information to travelers.
 [FieldDeviceCoreDetails](/spec-content/objects/FieldDeviceCoreDetails.md) | The core details—both configuration and current state—of a field device that are shared by all types of field devices.
 [FieldDeviceFeature](/spec-content/objects/FieldDeviceFeature.md) | The GeoJSON `Feature` container object for a deployed field device.
-[FlashingBeacon](/spec-content/objects/FlashingBeacon.md) | A flashing warning beacon used to supplement a temporary traffic control device. It is mounted on a sign or channelizing device that is used to indicate a warning condition and capture driver attention.
+[FlashingBeacon](/spec-content/objects/FlashingBeacon.md) | Describes a flashing warning beacon used to supplement a temporary traffic control device. A flashing warning beacon is mounted on a sign or channelizing device and used to indicate a warning condition and capture driver attention.
 [HybridSign](/spec-content/objects/HybridSign.md) | A hybrid sign that contains static text (e.g. on an alumium sign) along with a single electronic message display, used to provide information to travelers.
 [LocationMarker](/spec-content/objects/LocationMarker.md) | Describes any GPS-enabled ITS device that is placed at a point on a roadway to dynamically know the location of something (often the beginning or end of a work zone).
 [MarkedLocation](/spec-content/objects/MarkedLocation.md) | Describes a specific location where a [LocationMarker](/spec-content/objects/LocationMarker.md) is placed, such as the start or end of a work zone road event.

--- a/spec-content/README.md
+++ b/spec-content/README.md
@@ -59,7 +59,7 @@ Object | Description
 [DynamicMessagesSign](/spec-content/objects/DynamicMessageSign.md) | An electronic traffic sign deployed on the roadway, used to provide information to travelers.
 [FieldDeviceCoreDetails](/spec-content/objects/FieldDeviceCoreDetails.md) | The core details—both configuration and current state—of a field device that are shared by all types of field devices.
 [FieldDeviceFeature](/spec-content/objects/FieldDeviceFeature.md) | The GeoJSON `Feature` container object for a deployed field device.
-[FlashingBeacon](/spec-content/objects/FlashingBeacon.md) | A flashing beacon light of any form (e.g. trailer-mounted, vehicle), used to indicate something or capture driver attention.
+[FlashingBeacon](/spec-content/objects/FlashingBeacon.md) | A flashing warning beacon used to supplement a temporary traffic control device. It is mounted on a sign or channelizing device that is used to indicate a warning condition and capture driver attention.
 [HybridSign](/spec-content/objects/HybridSign.md) | A hybrid sign that contains static text (e.g. on an alumium sign) along with a single electronic message display, used to provide information to travelers.
 [LocationMarker](/spec-content/objects/LocationMarker.md) | Describes any GPS-enabled ITS device that is placed at a point on a roadway to dynamically know the location of something (often the beginning or end of a work zone).
 [MarkedLocation](/spec-content/objects/MarkedLocation.md) | Describes a specific location where a [LocationMarker](/spec-content/objects/LocationMarker.md) is placed, such as the start or end of a work zone road event.

--- a/spec-content/enumerated-types/FieldDeviceType.md
+++ b/spec-content/enumerated-types/FieldDeviceType.md
@@ -7,7 +7,7 @@ Value | Description
 `arrow-board` | An electronic, connected arrow board which can display an arrow pattern to direct traffic. See [ArrowBoard](/spec-content/objects/ArrowBoard.md).
 `camera` | A camera device deployed in the field, capable of capturing still images. See [Camera](/spec-content/objects/Camera.md).
 `dynamic-message-sign` | An electronic traffic sign deployed on the roadway, used to provide information to travelers. See [DynamicMessageSign](/spec-content/objects/DynamicMessageSign.md).
-`flashing-beacon` | A flashing beacon light of any form, used to indicate caution and capture driver attention. See [FlashingBeacon](/spec-content/objects/FlashingBeacon.md).
+`flashing-beacon` | A flashing warning beacon used to supplement a temporary traffic control device. See [FlashingBeacon](/spec-content/objects/FlashingBeacon.md).
 `hybrid-sign` | A message sign that contains both static text (e.g. on an aluminium board) along with a variable electronic message sign, used to provide information to travelers. See [HybridSign](/spec-content/objects/HybridSign.md).
 `location-marker` | Any GPS-enabled ITS device that is placed at a point on a roadway to mark a location (often the beginning or end of a road event). See [LocationMarker](/spec-content/objects/LocationMarker.md).
 `traffic-sensor` | A device deployed on a roadway which captures traffic metrics such as speed, volume, or occupancy. See [TrafficSensor](/spec-content/objects/TrafficSensor.md).

--- a/spec-content/objects/FlashingBeacon.md
+++ b/spec-content/objects/FlashingBeacon.md
@@ -1,5 +1,5 @@
 # FlashingBeacon Object
-The `FlashingBeacon` object describes a flashing warning beacon used to supplement a temporary traffic control device. It is mounted on a sign or channelizing device that is used to indicate a warning condition and capture driver attention.
+The `FlashingBeacon` object describes a flashing warning beacon used to supplement a temporary traffic control device. A flashing warning beacon is mounted on a sign or channelizing device and used to indicate a warning condition and capture driver attention.
 
 The `FlashingBeacon` is a type of field device; it has a `core_details` property which contains the [FieldDeviceCoreDetails](/spec-content/objects/FieldDeviceCoreDetails.md) and exists within a [FieldDeviceFeature](/spec-content/objects/FieldDeviceFeature.md).
 

--- a/spec-content/objects/FlashingBeacon.md
+++ b/spec-content/objects/FlashingBeacon.md
@@ -1,5 +1,5 @@
 # FlashingBeacon Object
-The `FlashingBeacon` object describes a flashing beacon light of any form (e.g. trailer-mounted, vehicle), used to indicate something and capture driver attention.
+The `FlashingBeacon` object describes a flashing warning beacon used to supplement a temporary traffic control device. It is mounted on a sign or channelizing device that is used to indicate a warning condition and capture driver attention.
 
 The `FlashingBeacon` is a type of field device; it has a `core_details` property which contains the [FieldDeviceCoreDetails](/spec-content/objects/FieldDeviceCoreDetails.md) and exists within a [FieldDeviceFeature](/spec-content/objects/FieldDeviceFeature.md).
 
@@ -15,4 +15,3 @@ Name | Type | Description | Conformance | Notes
 Property | Object
 --- | --- 
 `properties` | [FieldDeviceFeature](/spec-content/objects/FieldDeviceFeature.md)
-


### PR DESCRIPTION
This PR resolves #341 by updating the description of the [FlashingBeacon](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/FlashingBeacon.md) object to clarify that it should only be used a flashing warning beacon mounted on a temporary traffic control device.

### Current Description

> A flashing beacon light of any form (e.g. trailer-mounted, vehicle), used to indicate something and capture driver attention.

### Proposed Description

> A flashing warning beacon used to supplement a temporary traffic control device. A flashing warning beacon is mounted on a sign or channelizing device and used to indicate a warning condition and capture driver attention.