### PR TITLE
Add loops to Direction enumeration

### DIFF
--- a/schemas/4.2/Direction.json
+++ b/schemas/4.2/Direction.json
@@ -3,5 +3,5 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Direction Enumerated Type",
   "description": "The direction of a road based on standard naming for US roads; indicates the direction the traffic flow not the real heading angle.",
-  "enum": ["northbound", "eastbound", "southbound", "westbound", "undefined", "unknown"]
+  "enum": ["northbound", "eastbound", "southbound", "westbound", "undefined", "unknown", "inner-loop", "outer-loop"]
 }

--- a/spec-content/enumerated-types/Direction.md
+++ b/spec-content/enumerated-types/Direction.md
@@ -8,8 +8,8 @@ Value | Description
 `eastbound` | Road flow is in the eastbound direction
 `southbound` | Road flow is in the southbound direction
 `westbound` | Road flow is in the westbound direction
-`inner-loop` | Road flow is in the clockwise direction of a ring road or beltway.
-`outer-loop` | Road flow is in the counter-clockwise direction of a ring road or beltway.
+`inner-loop` | Road flow is on the inner loop of a ring road or beltway. In countries that drive on the right side of the road, this is the clockwise direction.
+`outer-loop` | Road flow is on the outer loop of a ring road or beltway. In countries that drive on the right side of the road, this is the counter-clockwise direction.
 `undefined` | Road flow does not have a signed direction. For a [RoadEventFeature](/spec-content/objects/RoadEventFeature.md), the first and last coordinates in the feature's geometry represent the beginning and end of the road event in the direction of travel it impacts.
 `unknown` | Road flow may have a signed direction, but the affected direction of travel is not known
 

--- a/spec-content/enumerated-types/Direction.md
+++ b/spec-content/enumerated-types/Direction.md
@@ -8,6 +8,8 @@ Value | Description
 `eastbound` | Road flow is in the eastbound direction
 `southbound` | Road flow is in the southbound direction
 `westbound` | Road flow is in the westbound direction
+`inner-loop` | Road flow is in the clockwise direction of a ring road or beltway.
+`outer-loop` | Road flow is in the counter-clockwise direction of a ring road or beltway.
 `undefined` | Road flow does not have a signed direction. For a [RoadEventFeature](/spec-content/objects/RoadEventFeature.md), the first and last coordinates in the feature's geometry represent the beginning and end of the road event in the direction of travel it impacts.
 `unknown` | Road flow may have a signed direction, but the affected direction of travel is not known
 


### PR DESCRIPTION
**EDITED 11/04/2022** to reflect new description for `inner-loop` and `outer-loop` that is internationally consistent. 

This PR adds two new values to the Direction enumerated type to support events on beltways or ring roads. Resolves #324. 

# Direction enumerated type
Value | Description
--- | ---
`northbound`| Road flow is in the northbound direction
`eastbound` | Road flow is in the eastbound direction
`southbound` | Road flow is in the southbound direction
`westbound` | Road flow is in the westbound direction
NEW `inner-loop` | Road flow is on the inner loop of a ring road or beltway. In countries that drive on the right side of the road, this is the clockwise direction.
NEW `outer-loop` | Road flow is on the outer loop of a ring road or beltway. In countries that drive on the right side of the road, this is the counter-clockwise direction.
`undefined` | Road flow does not have a signed direction. For a [RoadEventFeature](/spec-content/objects/RoadEventFeature.md), the first and last coordinates in the feature's geometry represent the beginning and end of the road event in the direction of travel it impacts.
`unknown` | Road flow may have a signed direction, but the affected direction of travel is not known

Question - should the descriptions change to be applicable to left-side traffic as well? How?