### PR TITLE
Update DeviceFeed schema to fix TrafficSignal 

### DIFF
--- a/schemas/4.1/DeviceFeed.json
+++ b/schemas/4.1/DeviceFeed.json
@@ -67,6 +67,9 @@
             },
             {
               "$ref": "#/definitions/TrafficSensor"
+            },
+            {
+              "$ref": "#/definitions/TrafficSignal"
             }
           ]
         },
@@ -526,17 +529,34 @@
     "TrafficSignal": {
       "title": "Traffic Signal",
       "description": "Describes a temporary traffic signal deployed on a roadway",
-      "properties": {
-        "core_details": {
-          "$ref": "#/definitions/FieldDeviceCoreDetails"
+      "allOf": [
+        {
+          "properties": {
+            "core_details": {
+              "properties": {
+                "device_type": {
+                  "const": "traffic-signal"
+                }
+              },
+              "required": ["device_type"]
+            }
+          },
+          "required": ["core_details"]
         },
-        "mode": {
-          "$ref": "#/definitions/TrafficSignalMode"
-        }   
-      },
-      "required": [
-        "core_details",
-        "mode"
+        {
+          "properties": {
+            "core_details": {
+              "$ref": "#/definitions/FieldDeviceCoreDetails"
+            },
+            "mode": {
+              "$ref": "#/definitions/TrafficSignalMode"
+            }   
+          },
+          "required": [
+            "core_details",
+            "mode",
+          ]
+        }
       ]
     },
     "ArrowBoardPattern": {


### PR DESCRIPTION
This PR fixes an issue in the WZDx v4.1 release with the TrafficSignal device schema. The TrafficSignal device schema now appropriately requires that the device type in FieldDeviceCoreDetails be "traffic-signal" and allows a FieldDeviceFeature to contain a TrafficSignal object.