### PR TITLE
Update DeviceFeed schema to fix trailing comma

### DIFF
--- a/schemas/4.1/DeviceFeed.json
+++ b/schemas/4.1/DeviceFeed.json
@@ -554,7 +554,7 @@
           },
           "required": [
             "core_details",
-            "mode",
+            "mode"
           ]
         }
       ]


### PR DESCRIPTION
Update DeviceFeed schema to fix issue caused by trailing comma. Resolves issue noted in [here](https://github.com/usdot-jpo-ode/wzdx/pull/360#issuecomment-1309247381)