### PR TITLE
Fix chevron enums in 4.1 and 4.2 schemas

### DIFF
--- a/schemas/4.1/DeviceFeed.json
+++ b/schemas/4.1/DeviceFeed.json
@@ -578,9 +578,9 @@
         "right-arrow-flashing",
         "right-arrow-sequential",
         "right-arrow-static",
-        "right-chevrons-flashing",
-        "right-chevrons-sequential",
-        "right-chevrons-static",
+        "right-chevron-flashing",
+        "right-chevron-sequential",
+        "right-chevron-static",
         "unknown"
       ]
     },

--- a/schemas/4.2/DeviceFeed.json
+++ b/schemas/4.2/DeviceFeed.json
@@ -582,9 +582,9 @@
         "right-arrow-flashing",
         "right-arrow-sequential",
         "right-arrow-static",
-        "right-chevrons-flashing",
-        "right-chevrons-sequential",
-        "right-chevrons-static",
+        "right-chevron-flashing",
+        "right-chevron-sequential",
+        "right-chevron-static",
         "unknown"
       ]
     },


### PR DESCRIPTION
Closes #365 

## Proposed Changes
Change DeviceFeed schema TrafficSignalMode enumberations starting `right-chevrons-` to `right-chevron-`

This issue was previously resolved for the v4.0 schema in #307 but the change was not carried over to the new v4.1 schema or v4.2 schema
