### PR TITLE
Fix typo in JSON schema for WorkerPresenceDefinition

### DIFF
--- a/schemas/4.1/RoadEventFeature.json
+++ b/schemas/4.1/RoadEventFeature.json
@@ -659,7 +659,7 @@
         "workers-in-work-zone-working",
         "workers-in-work-zone-not-working", 
         "mobile-equipment-in-work-zone-moving", 
-        "mobile-equipment-in-work-zone-not-working", 
+        "mobile-equipment-in-work-zone-not-moving", 
         "fixed-equipment-in-work-zone", 
         "humans-behind-barrier", 
         "humans-in-right-of-way"

--- a/schemas/4.2/RoadEventFeature.json
+++ b/schemas/4.2/RoadEventFeature.json
@@ -695,7 +695,7 @@
         "workers-in-work-zone-working",
         "workers-in-work-zone-not-working", 
         "mobile-equipment-in-work-zone-moving", 
-        "mobile-equipment-in-work-zone-not-working", 
+        "mobile-equipment-in-work-zone-not-moving", 
         "fixed-equipment-in-work-zone", 
         "humans-behind-barrier", 
         "humans-in-right-of-way"


### PR DESCRIPTION
This PR fixes a typo in the WZDx v4.1 and v4.2 Schema WorkerPresenceDefinition enumerated type. 

Per the markdown (main) documentation for [WorkerPresenceDefinition](https://github.com/usdot-jpo-ode/wzdx/blob/fix/typo-in-workerpresencedefinition-schema/spec-content/enumerated-types/WorkerPresenceDefinition.md), the value for when "Mobile equipment is in the work zone event area but is not moving." is `mobile-equipment-in-work-zone-not-moving`. However, in the schema it is `mobile-equipment-in-work-zone-not-working`.

This PR changes the schema so that it is consistent with the primary, markdown documentation (that is, "not-moving" rather than "not-working").